### PR TITLE
genbank ss-DNA should not be overwirte to DNA

### DIFF
--- a/packages/bio-parsers/src/genbankToJson.js
+++ b/packages/bio-parsers/src/genbankToJson.js
@@ -344,6 +344,9 @@ function genbankToJson(string, options = {}) {
           options.isProtein = false;
         }
         options.sequenceTypeFromLocus = item;
+        if (item.match(/ss-dna/i)) {
+          options.isSingleStrandedDNA = true;
+        }
       }
 
       // Division
@@ -364,6 +367,7 @@ function genbankToJson(string, options = {}) {
     }
     result.parsedSequence.gbDivision = gbDivision;
     result.parsedSequence.sequenceTypeFromLocus = options.sequenceTypeFromLocus;
+    result.parsedSequence.isSingleStrandedDNA = options.isSingleStrandedDNA;
     result.parsedSequence.date = date;
     result.parsedSequence.circular = circular;
   }

--- a/packages/bio-parsers/src/jsonToGenbank.js
+++ b/packages/bio-parsers/src/jsonToGenbank.js
@@ -207,7 +207,7 @@ function createGenbankLocus(serSeq, options) {
   } else if (serSeq.type === "RNA") {
     dnaType = "RNA";
   } else {
-    dnaType = "DNA";
+    dnaType = serSeq?.sequenceTypeFromLocus ?? "DNA";
   }
   const date = getCurrentDateString();
 


### PR DESCRIPTION
With this change the `ss-DNA` genebank file is exporting as `ss-DNA` like this pic
<img width="417" alt="image" src="https://github.com/TeselaGen/tg-oss/assets/28696796/22ea3d7b-ab22-43fe-9e57-eed805dce698">
