### PR TITLE
Omit package type if includes both es and cjs

### DIFF
--- a/tools/scripts/publish.mjs
+++ b/tools/scripts/publish.mjs
@@ -85,7 +85,6 @@ if (!version || version === "undefined") {
   json = JSON.parse(readFileSync(`package.json`).toString());
   try {
     json.version = version;
-    json.type = "commonjs";
     json.license = "MIT";
     json.dependencies = { ...deps, ...json.dependencies };
     writeFileSync(`package.json`, JSON.stringify(json, null, 2));


### PR DESCRIPTION
Hi @tnrich 

I have address the issue 3 here in the follow up comment https://github.com/TeselaGen/tg-oss/pull/25#issuecomment-1718141694 for webpack bundler

Additionally in order to address issue 1 and 2 to make the tests in oveViteDemo working, the @teselagen/ui package seems need to be republished