### PR TITLE
Removed * aa from dna translation at the end of sequence

### DIFF
--- a/packages/sequence-utils/src/getAminoAcidStringFromSequenceString.js
+++ b/packages/sequence-utils/src/getAminoAcidStringFromSequenceString.js
@@ -7,8 +7,12 @@ export default function getAminoAcidStringFromSequenceString(sequenceString) {
   );
   const aaArray = [];
   let aaString = "";
-  aminoAcidsPerBase.forEach(aa => {
+  aminoAcidsPerBase.forEach((aa, index) => {
     if (!aa.fullCodon) {
+      return;
+    }
+    // Check if the current amino acid is the last in the sequence and is a stop codon
+    if (index === aminoAcidsPerBase.length - 1 && aa.aminoAcid.value === '*') {
       return;
     }
     aaArray[aa.aminoAcidIndex] = aa.aminoAcid.value;

--- a/packages/sequence-utils/src/getAminoAcidStringFromSequenceString.test.js
+++ b/packages/sequence-utils/src/getAminoAcidStringFromSequenceString.test.js
@@ -14,5 +14,6 @@ describe("getAminoAcidStringFromSequenceString", () => {
     assert.equal("MM", getAminoAcidStringFromSequenceString("atgatg"));
     assert.equal("M--", getAminoAcidStringFromSequenceString("atg------"));
     assert.equal("", getAminoAcidStringFromSequenceString("at"));
+    assert.equal("MTNYNQKNEN", getAminoAcidStringFromSequenceString("atgactaattataatcaaaaaaatgaaaattaa"));
   });
 });


### PR DESCRIPTION
Before this PR, the tool is adding an * to aa sequences as the translation for the stop codon. This PR removes that * character at the end when getting aa sequences from DNA.