### PR TITLE
Issue 69 2

### DIFF
--- a/packages/sequence-utils/src/getAminoAcidDataForEachBaseOfDna.test.js
+++ b/packages/sequence-utils/src/getAminoAcidDataForEachBaseOfDna.test.js
@@ -5,6 +5,7 @@ import getAA from "./getAminoAcidFromSequenceTriplet";
 import assert from "assert";
 
 let aaData;
+let aaData2;
 describe("getAminoAcidDataForEachBaseOfDna tranlates a", () => {
   //: It gets correct amino acid mapping and position in codon for each basepair in sequence
   it("1 amino acid long sequence", () => {
@@ -418,5 +419,59 @@ describe("getAminoAcidDataForEachBaseOfDna tranlates a", () => {
         }
       }
     ]);
+  });
+  it("protein 1 amino acid long sequence", () => {
+    aaData = getAminoAcidDataForEachBaseOfDna("M", true, null, true);
+    aaData2 = getAminoAcidDataForEachBaseOfDna("atg", true, null, false);
+    assert.deepEqual(aaData, aaData2);
+  });
+  it("protein 1 amino acid long sequence in reverse direction", () => {
+    aaData = getAminoAcidDataForEachBaseOfDna("H", false, null, true);
+    aaData2 = getAminoAcidDataForEachBaseOfDna("atg", false, null, false);
+    assert.deepEqual(aaData, aaData2);
+  });
+  it("> 1 amino acid long sequence", () => {
+    aaData = getAminoAcidDataForEachBaseOfDna("MF", true, null, true);
+    aaData2 = getAminoAcidDataForEachBaseOfDna("atgttt", true, null, false);
+    assert.deepEqual(aaData, aaData2);
+  });
+  it("> 1 amino acid long sequence in reverse direction", () => {
+    aaData = getAminoAcidDataForEachBaseOfDna("KH", false, null, true);
+    aaData2 = getAminoAcidDataForEachBaseOfDna("atgttt", false, null, false);
+    assert.deepEqual(aaData, aaData2);
+  });
+  it.skip("protein 1 amino acid long sequence which is a subrange of a larger sequence", () => {
+    aaData = getAminoAcidDataForEachBaseOfDna(
+      "AMA",
+      true,
+      { start: 1, end: 1 },
+      true
+    );
+    aaData2 = getAminoAcidDataForEachBaseOfDna(
+      "xxxatgxxx",
+      true,
+      { start: 3, end: 5 },
+      false
+    );
+    // Unclear what the behavior should be here,
+    // for now it returns the same as the old code (ignores the start and end range)
+    assert.deepEqual(aaData, aaData2);
+  });
+  it.skip("protein 1 amino acid long sequence in reverse direaction which is a subrange of a larger sequence", () => {
+    aaData = getAminoAcidDataForEachBaseOfDna(
+      "AMA",
+      false,
+      { start: 1, end: 1 },
+      true
+    );
+    aaData2 = getAminoAcidDataForEachBaseOfDna(
+      "xxxatgxxx",
+      false,
+      { start: 3, end: 5 },
+      false
+    );
+    // Unclear what the behavior should be here,
+    // for now it returns the same as the old code (ignores the start and end range)
+    assert.deepEqual(aaData, aaData2);
   });
 });


### PR DESCRIPTION
Hi @tnrich, apologies in advance for the long issue, but there was a bunch of things.

This is the `sequence-utils` part of #69. There are three commits:

1. dcdaf447171cbb0ec0cbfdac7c5eb535314cc0b7: re-factor of [getAminoAcidDataForEachBaseOfDna.js](https://github.com/TeselaGen/tg-oss/commit/dcdaf447171cbb0ec0cbfdac7c5eb535314cc0b7#diff-00467a4dfd1efc3bff25bb1e1dbf76729387eed75b96a90df550366d19fad197). It removes special cases, and does everything in the same loop (before the `X` aminoacid corresponding to truncated codons was added separately and differently for forward and reverse translations). I think it makes the code a bit clearer, and I thought doing a single loop was necessary to implement the next feature. I have also splitted out some pre-processing into a separate function to have only the logic in `getAminoAcidDataForEachBaseOfDna`.
2. 878ce24fd3fcd27d9e8eb39a9e26f47a59678817: added a few extra tests for `getAminoAcidDataForEachBaseOfDna` in the protein case. Some are skipped (see below for questions on this).
3. 6c451353b8cead342ced0ad64d3336075165a3d3: actual implementation of the feature. Tests are still missing because I wanted to double-check with you a few things before writing them (see below).

Some tests fail, but I am not sure they are related to the feature I implemented. Some don't seem to (mainMenu fail for instance).

Below the questions I had

## Unrelated to the implementation

 * `optionalSubrangeRange` is a feature-like object (with `start` and `end`) passed to `getAminoAcidDataForEachBaseOfDna` to indicate the subset of the sequence that would be translated. Should this be allowed at all when `isProtein === true`? The reason why I ask is because now the `locations` of that feature are used to describe the exons (joined feature CDS-like) and that would be quite meaningless for a protein sequence. Not sure if it's worth to allow `optionalSubrangeRange` in the first place. The old code ignores the range for protein sequences (I have added some skipped tests to `getAminoAcidDataForEachBaseOfDna.test.js`, they are self-explaining). In my implementation, I have kept it that way, but it's probably best to return an error instead, since people may think that passing the range works for protein sequences.
 * I found the meaning of the `includeEndEdge` argument a bit confusing in the function `isPositionWithinRange`. For instance, with the name of the argument, I would have expected `isPositionWithinRange(3,{start:1,end:2}, 4, true, true)` to be false, and it's true. But `isPositionWithinRange(0,{start:1,end:2}, 4, true, true)` is false. I think it would be good to use a more self-explaining argument name or explain more in the docstring what exactly this argument represents.

 ## Related to the implementation

Right now, the output of `getAminoAcidDataForEachBaseOfDna` is an array that contains the aminoacid-level info for each basepair. For instance, for the bases `ATG` of the `ATG` of a CDS, the corresponding array is (where `getAA("atg")` returns an object with aminoacid properties):

```js
aaData = getAminoAcidDataForEachBaseOfDna("atg", true);
    assert.deepEqual(aaData, [
      {
        aminoAcid: getAA("atg"),
        positionInCodon: 0,
        aminoAcidIndex: 0,
        sequenceIndex: 0,
        codonRange: {
          start: 0,
          end: 2
        },
        fullCodon: true
      },
      {
        aminoAcid: getAA("atg"),
        positionInCodon: 1,
        aminoAcidIndex: 0,
        sequenceIndex: 1,
        codonRange: {
          start: 0,
          end: 2
        },
        fullCodon: true
      },
      {
        aminoAcid: getAA("atg"),
        positionInCodon: 2,
        aminoAcidIndex: 0,
        sequenceIndex: 2,
        codonRange: {
          start: 0,
          end: 2
        },
        fullCodon: true
      }
    ]);

```

The question is what to do when a basepair is part of an intron. The easiest thing (that gives the right representation in the UI) is to insert some kind of "mock" element in the array. Currently I am inserting something like this:

```js
{
    aminoAcid: null,
    positionInCodon: null,
    aminoAcidIndex: null,
    sequenceIndex: 2,
    codonRange: null,
    fullCodon: null
}
```

The function expects to have an array of the same length as the input protein sequence, so I think something in these lines makes the most sense. It also gives good rendering (see below). What do you think?

## Representation

As it is, it already gives a better representation that before (before the wrong amino acid sequence was displayed, because it was not taking into account the introns), but there are some awkward things.

You can see all the examples below in [example.zip](https://github.com/user-attachments/files/15548525/example.zip). You can reverse the sequence and rotate it and you can see that even if the features span the origin or inverted, they behave the same way.

If the intron does not split an aminoacid, it looks good:

![Screenshot 2024-06-04 at 10 54 17](https://github.com/TeselaGen/tg-oss/assets/22526102/0db1b400-7c9f-41a5-bb45-4dbacf527cce)

If the intron splits the aminoacid into two, the aminoacid is shown like this (displaced towards the side with most bases).

<img width="184" alt="Screenshot 2024-06-04 at 11 29 51" src="https://github.com/TeselaGen/tg-oss/assets/22526102/00fba369-7302-4adf-9ccb-f61fa28ac922">
<img width="181" alt="Screenshot 2024-06-04 at 11 29 19" src="https://github.com/TeselaGen/tg-oss/assets/22526102/6506c249-d5ee-4f66-a107-2656cc33a516">

There is also the case where the aminoacid is splitted into three exons, because there is an exon with a single basepair.

<img width="143" alt="Screenshot 2024-06-04 at 11 30 06" src="https://github.com/TeselaGen/tg-oss/assets/22526102/5f1f561a-2af0-422a-bd6d-a86852a1c879">

## Improvements to representation?

For amino acids that are splitted into several exons, I think it would be better to use the representation that is used when the aminoacid is splitted between two lines in the sequence map (bottom image), so there would be a fragment of the aminoacid symbol in each bit of the intron. I can give a go at this if you give me some guidance.

<img width="57" alt="Screenshot 2024-06-04 at 11 31 31" src="https://github.com/TeselaGen/tg-oss/assets/22526102/f5a36e28-cd7d-4d3f-b036-ee4bee19efd6">

I think it would also be good to have a thin line joining the translation bits that correspond to the same CDS, like the thin line that connects the different `positions` in a feature with multiple parts, something like below. I can give a go at this if you give me some advice as well.

![Screenshot 2024-06-04 at 10 54 17](https://github.com/TeselaGen/tg-oss/assets/22526102/a63b5959-e6bf-482b-9d59-7933a74d3c0f)


