### PR TITLE
feature display correct. Problem with reverse complement

### DIFF
--- a/packages/ove/demo/src/exampleData/exampleSequenceData.js
+++ b/packages/ove/demo/src/exampleData/exampleSequenceData.js
@@ -8,6 +8,7 @@ export default {
       forward: true,
       locations: [
         { start: 0, end: 3 },
+        { start: 5, end: 5 },
         { start: 7, end: 10 }
       ],
       id: "12kkoo",

--- a/packages/ove/src/RowItem/Translations/AASliver.js
+++ b/packages/ove/src/RowItem/Translations/AASliver.js
@@ -36,8 +36,8 @@ function AASliver(props) {
   path = isFiller
     ? "25,0 49,0 60,50 49,100 25,100 38,50 25,0"
     : isTruncatedStart
-    ? // ? "0,0 50,0 60,50 50,100 00,100 16,50 0,0"
-      `M ${roundedCorner / 3}, 0
+      ? // ? "0,0 50,0 60,50 50,100 00,100 16,50 0,0"
+        `M ${roundedCorner / 3}, 0
                   L ${50 - roundedCorner / 3}, 0
                   Q 50 0 ${50 + roundedCorner * dirX1} ${roundedCorner * dirY1}
                   L ${60 - roundedCorner * dirX1}, ${50 - roundedCorner * dirY1}
@@ -59,9 +59,9 @@ function AASliver(props) {
                   L ${roundedCorner * dirX2}, ${roundedCorner * dirY2}
                   Q 0 0 ${roundedCorner / 3} 0
                   z`
-    : isTruncatedEnd
-    ? // ? "24,0 74,0 84,50 74,100 24,100 40,50 24,0"
-      `M ${24 + roundedCorner / 3}, 0
+      : isTruncatedEnd
+        ? // ? "24,0 74,0 84,50 74,100 24,100 40,50 24,0"
+          `M ${24 + roundedCorner / 3}, 0
                   L ${74 - roundedCorner / 3}, 0
                   Q 74 0 ${74 + roundedCorner * dirX1} ${roundedCorner * dirY1}
                   L ${84 - roundedCorner * dirX1}, ${50 - roundedCorner * dirY1}
@@ -83,7 +83,7 @@ function AASliver(props) {
                   L ${24 + roundedCorner * dirX2}, ${roundedCorner * dirY2}
                   Q 24 0 ${24 + roundedCorner / 3} 0
                   z`
-    : `M ${roundedCorner / 3}, 0
+        : `M ${roundedCorner / 3}, 0
                   L ${74 - roundedCorner / 3}, 0
                   Q 74 0 ${74 + roundedCorner * dirX1} ${roundedCorner * dirY1}
                   L ${84 - roundedCorner * dirX1}, ${50 - roundedCorner * dirY1}
@@ -130,10 +130,10 @@ function AASliver(props) {
               isFiller
                 ? "25,0 49,0 60,50 49,100 25,100 38,50 25,0"
                 : isTruncatedStart
-                ? "0,0 50,0 60,50 50,100 00,100 16,50 0,0"
-                : isTruncatedEnd
-                ? "24,0 74,0 84,50 74,100 24,100 40,50 24,0"
-                : "0,0 74,0 85,50 74,100 0,100 16,50 0,0"
+                  ? "0,0 50,0 60,50 50,100 00,100 16,50 0,0"
+                  : isTruncatedEnd
+                    ? "24,0 74,0 84,50 74,100 24,100 40,50 24,0"
+                    : "0,0 74,0 85,50 74,100 0,100 16,50 0,0"
             }
             strokeWidth="5"
             fill={color || "gray"}
@@ -148,7 +148,8 @@ function AASliver(props) {
           />
         ))}
 
-      {!isFiller && (
+      {/* isTruncatedEnd && isTruncatedStart is the special case of a single base exon */}
+      {(!isFiller || (isTruncatedEnd && isTruncatedStart)) && (
         <text
           fontSize={25}
           stroke="black"

--- a/packages/ove/src/RowItem/Translations/Translation.js
+++ b/packages/ove/src/RowItem/Translations/Translation.js
@@ -132,7 +132,12 @@ class Translation extends React.Component {
 
         return (
           <AASliver
-            isFiller={isEndFiller || isStartFiller}
+            // isTruncatedEnd && isTruncatedStart is the special case of a single base exon
+            isFiller={
+              isEndFiller ||
+              isStartFiller ||
+              (isTruncatedEnd && isTruncatedStart)
+            }
             isTruncatedEnd={isTruncatedEnd}
             isTruncatedStart={isTruncatedStart}
             onClick={function (event) {

--- a/packages/ove/src/RowItem/Translations/Translation.js
+++ b/packages/ove/src/RowItem/Translations/Translation.js
@@ -59,6 +59,9 @@ class Translation extends React.Component {
     //we then loop over all the amino acids in the sub range and draw them onto the row
     let prevAaSliver;
     let nextAaSliver = aminoAcidsForSubrange[1];
+    // The last index in the sequence
+    const lastIndex = aminoAcidsForSubrange.length - 1;
+
     const translationSVG = aminoAcidsForSubrange.map(
       function (aminoAcidSliver, index) {
         if (aminoAcidSliver.positionInCodon === null) {
@@ -77,22 +80,20 @@ class Translation extends React.Component {
           );
         }
         const isEndFiller =
-          (prevAaSliver?.positionInCodon === null &&
-            aminoAcidSliver.positionInCodon === 1) ||
-          (index === 0 &&
-            aminoAcidSliver.positionInCodon === (annotation.forward ? 2 : 0));
+          (index === 0 || prevAaSliver?.positionInCodon === null) &&
+          aminoAcidSliver.positionInCodon === (annotation.forward ? 2 : 0);
 
         const isStartFiller =
-          (nextAaSliver?.positionInCodon === null &&
-            aminoAcidSliver.positionInCodon === 0) ||
-          (index === aminoAcidsForSubrange.length - 1 &&
-            aminoAcidSliver.positionInCodon === (annotation.forward ? 0 : 2));
+          (index === lastIndex || nextAaSliver?.positionInCodon === null) &&
+          aminoAcidSliver.positionInCodon === (annotation.forward ? 0 : 2);
 
         let isTruncatedEnd =
-          index === 0 && aminoAcidSliver.positionInCodon === 1;
-        let isTruncatedStart =
-          index === aminoAcidsForSubrange.length - 1 &&
+          (index === 0 || prevAaSliver?.positionInCodon === null) &&
           aminoAcidSliver.positionInCodon === 1;
+        let isTruncatedStart =
+          (index === lastIndex || nextAaSliver?.positionInCodon === null) &&
+          aminoAcidSliver.positionInCodon === 1;
+
         if (!annotation.forward) {
           const holder = isTruncatedEnd;
           isTruncatedEnd = isTruncatedStart;


### PR DESCRIPTION
Hi @tnrich,

This makes it work for all cases, see [example2.zip](https://github.com/user-attachments/files/15586158/example2.zip)

<img width="684" alt="Screenshot 2024-06-05 at 12 43 24" src="https://github.com/TeselaGen/tg-oss/assets/22526102/f7bc95fb-b7e7-4159-9f95-0bc1ab9ea88a">

I have splitted it into two commits, the first one completes the logic that you started adding, the second one adds some extra logic to handle  the special case of a single base exon (where `isTruncatedEnd` && `isTruncatedStart` but should be displayed as `isFiller` with text), see how the result looks in the left and right features in the bottom lane of the image above.

I noticed however that the current implementation of `getAminoAcidDataForEachBaseOfDna` messes up with `Edit > Reverse complement entire sequence`. This causes this error stack:

<img width="596" alt="Screenshot 2024-06-05 at 12 49 42" src="https://github.com/TeselaGen/tg-oss/assets/22526102/82962718-adfc-4b1b-a3de-d318b279a6a3">

I don't think this is related to what I implemented, since reverse-complementing the sequence outside of ove and loading it causes no problem. I think the function `getAminoAcidDataForEachBaseOfDna` is being called when not everything in the features has been updated after reverse complementing? Or maybe existing translations cause the problem?

