### PR TITLE
Divide DataTable & upgrade react-dom

### DIFF
--- a/example-demos/oveViteDemo/src/index.jsx
+++ b/example-demos/oveViteDemo/src/index.jsx
@@ -1,6 +1,6 @@
 import "./shimGlobal";
 import React from "react";
-import ReactDOM from "react-dom";
+import { createRoot } from "react-dom/client";
 import { Provider } from "react-redux";
 import { Loading } from "@teselagen/ui";
 
@@ -10,14 +10,16 @@ import App from "./App";
 
 import * as serviceWorker from "./serviceWorker";
 
-ReactDOM.render(
+const domNode = document.getElementById("root");
+const root = createRoot(domNode);
+
+root.render(
   <React.StrictMode>
     <Provider store={store}>
       <Loading />
       <App />
     </Provider>
-  </React.StrictMode>,
-  document.getElementById("root")
+  </React.StrictMode>
 );
 
 // If you want your app to work offline and load faster, you can change

--- a/example-demos/oveWebpackDemo/src/index.jsx
+++ b/example-demos/oveWebpackDemo/src/index.jsx
@@ -1,15 +1,17 @@
 import React from "react";
-import ReactDOM from "react-dom";
+import { createRoot } from "react-dom/client";
 import { Provider } from "react-redux";
 import store from "./store";
 import "./index.css";
 import App from "./App";
 
-ReactDOM.render(
+const domNode = document.getElementById("root");
+const root = createRoot(domNode);
+
+root.render(
   <React.StrictMode>
     <Provider store={store}>
       <App />
     </Provider>
-  </React.StrictMode>,
-  document.getElementById("root")
+  </React.StrictMode>
 );

--- a/helperUtils/renderDemo.js
+++ b/helperUtils/renderDemo.js
@@ -1,2 +1,0 @@
-import { render } from "react-dom";
-export default Demo => render(<Demo></Demo>, document.querySelector("#demo"));

--- a/helperUtils/renderDemo.jsx
+++ b/helperUtils/renderDemo.jsx
@@ -1,0 +1,3 @@
+import { createRoot } from "react-dom/client";
+const root = createRoot(document.querySelector("#demo"));
+export default Demo => root.render(<Demo />);

--- a/packages/ui/cypress/e2e/EditableCellTable.spec.js
+++ b/packages/ui/cypress/e2e/EditableCellTable.spec.js
@@ -29,8 +29,6 @@ describe("EditableCellTable.spec", () => {
     cy.get(".cellDragHandle");
     cy.get(`[data-test="tgCell_name"]:first`).dblclick();
     cy.get(".cellDragHandle").should("not.exist");
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(0);
     cy.focused().type("_zonk{enter}");
     cy.get(
       `[data-tip="Must include the letter 'a'"] [data-test="tgCell_name"]:first`
@@ -39,8 +37,6 @@ describe("EditableCellTable.spec", () => {
   });
   it(`typing a letter should start edit`, () => {
     cy.visit("#/DataTable%20-%20EditableCellTable");
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(0);
     cy.get(`[data-test="tgCell_name"]:first`).type("zonk{enter}");
     cy.get(`[data-test="tgCell_name"]:first`).should("contain", "zonk");
   });
@@ -126,8 +122,6 @@ describe("EditableCellTable.spec", () => {
       `[data-tip="Must be a number"] [data-test="tgCell_howMany"]:first`
     ).should("contain", "NaN"); //should lowercase "Tom"
     cy.get(`[data-test="tgCell_howMany"]:first`).dblclick();
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(0);
     cy.focused().type("11{enter}");
     cy.get(`[data-test="tgCell_howMany"]:first`).should("contain", "12"); //should have 12 post format
     cy.get(
@@ -166,10 +160,10 @@ describe("EditableCellTable.spec", () => {
   //   cy.get(
   //     `.rt-td.isSelectedCell.isPrimarySelected [data-test="tgCell_name"]`
   //   ).should("not.exist");
-  //   cy.get(`[data-test="tgCell_name"]`).eq(3).click({ force: true });
+  //   cy.get(`[data-test="tgCell_name"]`).eq(3).click();
   //   cy.get(`.rt-td.isSelectedCell.isPrimarySelected [data-test="tgCell_name"]`);
-  //   cy.focused().type(`{enter}`)
-  //   cy.focused().type(`haha{enter}`)
+  //   cy.focused().type(`{enter}`);
+  //   cy.focused().type(`haha{enter}`);
   //   cy.get(
   //     `.rt-td.isSelectedCell.isPrimarySelected [data-test="tgCell_name"]`
   //   ).should("not.exist");
@@ -231,9 +225,7 @@ describe("EditableCellTable.spec", () => {
     cy.get(
       `[data-index="1"] .rt-td.isSelectedCell.isPrimarySelected [data-test="tgCell_type"]`
     );
-    cy.get(`[data-index="49"] [data-test="tgCell_isProtein"]`).click({
-      force: true
-    });
+    cy.get(`[data-index="49"] [data-test="tgCell_isProtein"]`).click();
     cy.get(
       `[data-index="49"] .rt-td.isSelectedCell.isPrimarySelected [data-test="tgCell_isProtein"]`
     );
@@ -253,12 +245,8 @@ describe("EditableCellTable.spec", () => {
     const redoCmd = IS_LINUX ? `{alt}{shift}z` : "{meta}{shift}z";
     cy.visit("#/DataTable%20-%20EditableCellTable");
     cy.get(`.rt-td:contains(tom88)`).dblclick();
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(0);
     cy.focused().type("{selectall}tasty55{enter}");
     cy.get(`.rt-td:contains(tasty55)`).dblclick();
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(0);
     cy.focused().type("{selectall}delishhh{enter}");
     cy.get(`.rt-td:contains(delishhh)`);
     cy.focused().type(undoCmd);

--- a/packages/ui/cypress/e2e/UploadCsvWizard.spec.js
+++ b/packages/ui/cypress/e2e/UploadCsvWizard.spec.js
@@ -147,17 +147,6 @@ describe("UploadCsvWizard.spec", () => {
   });
   it(`messed up headers should trigger the wizard. editing the added file should work`, () => {
     cy.visit("#/UploadCsvWizard");
-    // cy.contains("Build CSV File").click();
-    // cy.get(`.rt-td [data-test="tgCell_description"]`)
-    //   .eq(1)
-    //   .click({ force: true });
-    // cy.focused().type("description{enter}");
-
-    // cy.get(
-    //   `.hasCellError[data-tip="Please enter a value here"] [data-test="tgCell_name"]:first`
-    // ).dblclick({ force: true });
-    // cy.focused().type("a{enter}");
-    // cy.contains(`.bp3-dialog button`, "Cancel").click();
     cy.uploadFile(
       ".tg-dropzone",
       "testUploadWizard_messedUpHeaders.csv",
@@ -177,19 +166,21 @@ describe("UploadCsvWizard.spec", () => {
     );
 
     cy.get(`.tg-test-is-regex`).click();
-    cy.contains(".tg-select-option", "typo").click({ force: true });
+    cy.contains(".tg-select-option", "typo").click();
     cy.contains(".bp3-dialog", `zonk`).should("exist"); //the data from the file should be previewed
 
     cy.contains("Review and Edit Data").click();
 
     cy.get(
       `.hasCellError[data-tip="Please enter a value here"] [data-test="tgCell_name"]:first`
-    ).dblclick({ force: true });
-    cy.focused().type("a{enter}");
+    )
+      .parent()
+      .type("a{enter}");
     cy.get(
       `.hasCellError[data-tip="Please enter a value here"] [data-test="tgCell_sequence"]:first`
-    ).dblclick({ force: true });
-    cy.focused().type("g{enter}");
+    )
+      .parent()
+      .type("g{enter}");
     cy.dragBetween(`.cellDragHandle`, `.rt-tr-last-row`);
     cy.contains("Add File").click();
     cy.contains(`testUploadWizard_messedUpHeaders.csv`);
@@ -197,7 +188,7 @@ describe("UploadCsvWizard.spec", () => {
     cy.get(`.tg-upload-file-list-item-edit`).click();
     cy.contains(`Edit your data here.`);
     cy.get(
-      `[data-index="4"] [data-test="tgCell_sequence"]:contains(g)`
+      `[data-index="4"] [data-test="tgCell_sequence"]:contains(g):last`
     ).click();
     cy.focused().type(`{backspace}`);
     cy.get(`.bp3-disabled:contains(Edit Data)`);
@@ -646,13 +637,7 @@ a,,desc,,false,dna,misc_feature
     cy.contains(".bp3-dialog", `DEscription`); //the matched headers should show up
     cy.contains(".bp3-dialog", `Description`); //the expected headers should show up
     cy.contains("Review and Edit Data").click();
-    cy.get(`[data-tip="Please enter a value here"]`);
-    cy.get(`.hasCellError:last [data-test="tgCell_name"]`);
-    cy.get(`button:contains(Next File).bp3-disabled`);
-    cy.get(`.hasCellError:last [data-test="tgCell_name"]`).click({
-      force: true
-    });
-    cy.focused().type("haha{enter}");
+    cy.get(`.hasCellError`).type("haha{enter}");
     // cy.get(`.hasCellError:last [data-test="tgCell_name"]`).type("haha{enter}", {force: true});
     cy.get(`button:contains(Next File):first`).click();
     cy.get(
@@ -676,9 +661,7 @@ a,,desc,,false,dna,misc_feature
     cy.get(
       `.tg-upload-file-list-item:contains(testUploadWizard_invalidDataNonUnique.csv) .tg-upload-file-list-item-edit`
     ).click();
-    cy.get(`[data-index="0"] [data-test="tgCell_sequence"]`).click({
-      force: true
-    });
+    cy.get(`[data-index="0"] [data-test="tgCell_sequence"]:last`).click();
     cy.focused().type(`tom{enter}`);
     cy.get(`.bp3-button:contains(Edit Data)`).click();
     cy.contains(`File Updated`);
@@ -687,9 +670,7 @@ a,,desc,,false,dna,misc_feature
     cy.get(
       `.tg-upload-file-list-item:contains(testUploadWizard_invalidData.csv) .tg-upload-file-list-item-edit`
     ).click();
-    cy.get(`[data-index="0"] [data-test="tgCell_sequence"]`).click({
-      force: true
-    });
+    cy.get(`[data-index="0"] [data-test="tgCell_sequence"]`).click();
     // eslint-disable-next-line cypress/no-unnecessary-waiting
     cy.wait(200);
     cy.focused().type(`robbin{enter}`, { delay: 100 });
@@ -1065,14 +1046,14 @@ thomas,,g,false,dna,misc_feature`,
     cy.visit("#/UploadCsvWizard");
     cy.tgToggle("allowMultipleFiles");
     cy.contains("Build CSV File").click();
-    cy.get(`[data-test="tgCell_name"]:first`).click({ force: true });
+    cy.get(`.rt-tbody [role="gridcell"]:first`).click();
     cy.focused().paste(`Thomas	Wee	agagag	False	dna	misc_feature`);
     cy.contains(".bp3-button", "Add File").click();
     cy.contains("manual_data_entry.csv");
     // eslint-disable-next-line cypress/no-unnecessary-waiting
     cy.wait(200);
     cy.contains("Build CSV File").click();
-    cy.get(`[data-test="tgCell_name"]:first`).click({ force: true });
+    cy.get(`.rt-tbody [role="gridcell"]:first`).click();
     cy.focused().paste(`Thomas	Wee	agagag	False	dna	misc_feature`);
     cy.contains(".bp3-button", "Add File").click();
     cy.contains("manual_data_entry(1).csv");
@@ -1081,13 +1062,11 @@ thomas,,g,false,dna,misc_feature`,
     ).click();
     cy.contains(`Edit your data here.`);
     cy.contains(`Add 10 Rows`).click();
-    cy.get(`[data-index="4"] [data-test="tgCell_sequence"]`).click({
-      force: true
-    });
+    cy.get(`[data-index="4"] [role="gridcell"]`).eq(2).click();
     cy.focused().type(`{backspace}`);
     cy.get(`.bp3-disabled:contains(Edit Data)`).should("not.exist");
     cy.focused().type(`tom{enter}`);
-    cy.get(`[data-index="4"] [data-test="tgCell_name"]`).click({ force: true });
+    cy.get(`[data-index="4"] [role="gridcell"]:first`).click();
     cy.focused().type(`taoh{enter}`);
     cy.get(`.bp3-button:contains(Edit Data)`).click();
     cy.contains(`File Updated`);
@@ -1096,9 +1075,7 @@ thomas,,g,false,dna,misc_feature`,
     cy.get(
       `.tg-upload-file-list-item:contains(manual_data_entry(1).csv) .tg-upload-file-list-item-edit`
     ).click();
-    cy.get(`[data-index="0"] [data-test="tgCell_sequence"]`).click({
-      force: true
-    });
+    cy.get(`[data-index="0"] [role="gridcell"]`).eq(2).click();
     cy.focused().type(`tom{enter}`);
     cy.get(`.bp3-button:contains(Edit Data)`).click();
     cy.contains(`File Updated`);
@@ -1213,23 +1190,14 @@ thomas,,g,false,dna,misc_feature`,
     cy.contains(
       `Input your data here. Hover table headers for additional instructions`
     );
-    cy.get(`.rt-td [data-test="tgCell_description"]`)
-      .eq(1)
-      .click({ force: true });
-    cy.focused().type("description{enter}");
+    cy.get(".rt-td").eq(1).type("description{enter}");
 
     //there should be a checkbox in the isRegex boolean column
     cy.get(`[data-test="Is Regex"] .bp3-checkbox`);
 
     //should be able to edit and then drag to continue that edit further down
-    cy.get(
-      `.hasCellError[data-tip="Please enter a value here"] [data-test="tgCell_name"]:first`
-    ).dblclick({ force: true });
-    cy.focused().type("a{enter}");
-    cy.get(
-      `.hasCellError[data-tip="Please enter a value here"] [data-test="tgCell_sequence"]:first`
-    ).dblclick({ force: true });
-    cy.focused().type("g{enter}");
+    cy.get(".rt-td").eq(0).type("a{enter}");
+    cy.get(".rt-td").eq(2).type("g{enter}");
 
     cy.contains(".bp3-button", "Add File").click();
     cy.contains("File Added");

--- a/packages/ui/cypress/e2e/dataTable.spec.js
+++ b/packages/ui/cypress/e2e/dataTable.spec.js
@@ -9,8 +9,7 @@ describe("dataTable.spec", () => {
     cy.tgToggle("getRowClassName");
     cy.get(".rt-tr-group.custom-getRowClassName").should("exist");
   });
-  //TODO THIS IS BREAKING!
-  it.skip(`it can select entities across pages`, () => {
+  it(`it can select entities across pages`, () => {
     cy.visit("#/DataTable");
     cy.contains("0 Selected");
     //select first entity
@@ -162,7 +161,7 @@ describe("dataTable.spec", () => {
     checkIndices("greaterThan");
   });
 
-  it.skip("page size will persist on reload", () => {
+  it("page size will persist on reload", () => {
     cy.visit("#/DataTable");
     cy.get(".data-table-container .paging-page-size").should("have.value", "5");
     cy.get(".data-table-container .paging-page-size").select("50");

--- a/packages/ui/cypress/e2e/upload.spec.js
+++ b/packages/ui/cypress/e2e/upload.spec.js
@@ -59,7 +59,7 @@ describe("upload", () => {
       true
     );
 
-    cy.contains("type must be .json");
+    cy.contains("type must be .zip, .json");
     cy.uploadBlobFiles(
       ".fileUploadLimitAndType.tg-dropzone",
       [

--- a/packages/ui/cypress/support/index.js
+++ b/packages/ui/cypress/support/index.js
@@ -46,9 +46,7 @@ Cypress.Commands.add("dragBetween", (dragSelector, dropSelector) => {
   getOrWrap(dragSelector)
     .trigger("mousedown")
     .trigger("mousemove", 10, 10, { force: true });
-  getOrWrap(dropSelector)
-    .trigger("mousemove", { force: true })
-    .trigger("mouseup", { force: true });
+  getOrWrap(dropSelector).trigger("mousemove").trigger("mouseup");
 });
 
 Cypress.Commands.add(

--- a/packages/ui/demo/src/examples/UploadCsvWizard.js
+++ b/packages/ui/demo/src/examples/UploadCsvWizard.js
@@ -6,7 +6,7 @@ import { FileUploadField } from "../../../src";
 import DemoWrapper from "../DemoWrapper";
 import { reduxForm } from "redux-form";
 import { useToggle } from "../useToggle";
-import getIdOrCodeOrIndex from "../../../src/DataTable/utils/getIdOrCodeOrIndex";
+import { getIdOrCodeOrIndex } from "../../../src/DataTable/utils";
 
 const simpleValidateAgainst = {
   fields: [{ path: "name" }, { path: "description" }, { path: "sequence" }]

--- a/packages/ui/demo/src/examples/UploaderDemo.js
+++ b/packages/ui/demo/src/examples/UploaderDemo.js
@@ -21,10 +21,6 @@ export default function UploaderDemo() {
   const [autoUnzip, autoUnzipToggleComp] = useToggle({
     type: "autoUnzip"
   });
-  // const [advancedAccept, advancedAcceptToggleComp] = useToggle({
-  //   type: "accept",
-  //   label: "Toggle Advance Accept"
-  // });
   return (
     <div>
       <OptionsSection>

--- a/packages/ui/demo/src/index.js
+++ b/packages/ui/demo/src/index.js
@@ -25,7 +25,6 @@ import ScrollToTopDemo from "./examples/ScrollToTop";
 import showAppSpinnerDemo from "./examples/showAppSpinnerDemo";
 import EditableCellTable from "./examples/EditableCellTable";
 import React from "react";
-import { render } from "react-dom";
 import { Provider } from "react-redux";
 import store from "./store";
 import { FocusStyleManager } from "@blueprintjs/core";
@@ -33,6 +32,7 @@ import AdvancedOptionsDemo from "./examples/AdvancedOptionsDemo";
 import FormComponents from "./examples/FormComponents";
 import UploadCsvWizard from "./examples/UploadCsvWizard";
 import TagSelectDemo from "./examples/TagSelectDemo";
+import { createRoot } from "react-dom/client";
 
 FocusStyleManager.onlyShowFocusOnTabs();
 
@@ -261,4 +261,5 @@ const Demo = () => {
   );
 };
 
-render(<Demo />, document.querySelector("#demo"));
+const root = createRoot(document.querySelector("#demo"));
+root.render(<Demo />);

--- a/packages/ui/src/DataTable/CellDragHandle.js
+++ b/packages/ui/src/DataTable/CellDragHandle.js
@@ -1,21 +1,20 @@
 import { flatMap } from "lodash-es";
 import { forEach } from "lodash-es";
 import React, { useRef } from "react";
-import ReactDOM from "react-dom";
 
-export function CellDragHandle({
+export const CellDragHandle = ({
   thisTable,
   onDragEnd,
   cellId,
   isSelectionARectangle
-}) {
+}) => {
   const xStart = useRef(0);
   const timeoutkey = useRef();
   const rowsToSelect = useRef();
   const rectangleCellPaths = useRef();
 
   const handleDrag = useRef(e => {
-    const table = ReactDOM.findDOMNode(thisTable).querySelector(".rt-table");
+    const table = thisTable.querySelector(".rt-table");
     const trs = table.querySelectorAll(`.rt-tr-group.with-row-data`);
     const [rowId, path] = cellId.split(":");
     const selectedTr = table.querySelector(
@@ -83,7 +82,7 @@ export function CellDragHandle({
 
   const mouseup = useRef(() => {
     clearTimeout(timeoutkey.current);
-    const table = ReactDOM.findDOMNode(thisTable);
+    const table = thisTable;
     const trs = table.querySelectorAll(`.rt-tr-group.with-row-data`);
     const [, path] = cellId.split(":");
     //remove the dashed borders
@@ -126,6 +125,6 @@ export function CellDragHandle({
         document.addEventListener("mouseup", mouseup.current, false);
       }}
       className="cellDragHandle"
-    ></div>
+    />
   );
-}
+};

--- a/packages/ui/src/DataTable/ColumnFilterMenu.js
+++ b/packages/ui/src/DataTable/ColumnFilterMenu.js
@@ -1,0 +1,60 @@
+import React, { useState } from "react";
+import classNames from "classnames";
+import { Icon, Popover } from "@blueprintjs/core";
+
+export const ColumnFilterMenu = ({
+  addFilters,
+  compact,
+  currentFilter,
+  currentParams,
+  dataType,
+  extraCompact,
+  filterActiveForColumn,
+  FilterMenu,
+  filterOn,
+  removeSingleFilter,
+  schemaForField,
+  setNewParams
+}) => {
+  const [columnFilterMenuOpen, setColumnFilterMenuOpen] = useState(false);
+  return (
+    <Popover
+      position="bottom"
+      onClose={() => {
+        setColumnFilterMenuOpen(false);
+      }}
+      isOpen={columnFilterMenuOpen}
+      modifiers={{
+        preventOverflow: { enabled: true },
+        hide: { enabled: false },
+        flip: { enabled: false }
+      }}
+    >
+      <Icon
+        style={{ marginLeft: 5 }}
+        icon="filter"
+        iconSize={extraCompact ? 14 : undefined}
+        onClick={() => {
+          setColumnFilterMenuOpen(!columnFilterMenuOpen);
+        }}
+        className={classNames("tg-filter-menu-button", {
+          "tg-active-filter": !!filterActiveForColumn
+        })}
+      />
+      <FilterMenu
+        addFilters={addFilters}
+        compact={compact}
+        currentFilter={currentFilter}
+        currentParams={currentParams}
+        dataType={dataType}
+        filterOn={filterOn}
+        removeSingleFilter={removeSingleFilter}
+        schemaForField={schemaForField}
+        setNewParams={setNewParams}
+        togglePopover={() => {
+          setColumnFilterMenuOpen(false);
+        }}
+      />
+    </Popover>
+  );
+};

--- a/packages/ui/src/DataTable/DropdownCell.js
+++ b/packages/ui/src/DataTable/DropdownCell.js
@@ -1,0 +1,61 @@
+import React, { useState } from "react";
+import classNames from "classnames";
+import TgSelect from "../TgSelect";
+
+export const DropdownCell = ({
+  options,
+  isMulti,
+  initialValue,
+  finishEdit,
+  cancelEdit,
+  dataTest
+}) => {
+  const [v, setV] = useState(
+    isMulti
+      ? initialValue.split(",").map(v => ({ value: v, label: v }))
+      : initialValue
+  );
+  return (
+    <div
+      className={classNames("tg-dropdown-cell-edit-container", {
+        "tg-dropdown-cell-edit-container-multi": isMulti
+      })}
+    >
+      <TgSelect
+        small
+        multi={isMulti}
+        autoOpen
+        value={v}
+        onChange={val => {
+          if (isMulti) {
+            setV(val);
+            return;
+          }
+          finishEdit(val ? val.value : null);
+        }}
+        {...dataTest}
+        popoverProps={{
+          onClose: e => {
+            if (isMulti) {
+              if (e && e.key === "Escape") {
+                cancelEdit();
+              } else {
+                finishEdit(
+                  v && v.map
+                    ? v
+                        .map(v => v.value)
+                        .filter(v => v)
+                        .join(",")
+                    : v
+                );
+              }
+            } else {
+              cancelEdit();
+            }
+          }
+        }}
+        options={options.map(value => ({ label: value, value }))}
+      />
+    </div>
+  );
+};

--- a/packages/ui/src/DataTable/EditabelCell.js
+++ b/packages/ui/src/DataTable/EditabelCell.js
@@ -1,0 +1,48 @@
+import React, { useState } from "react";
+
+export const EditableCell = ({
+  shouldSelectAll,
+  stopSelectAll,
+  initialValue,
+  finishEdit,
+  cancelEdit,
+  isNumeric,
+  dataTest
+}) => {
+  const [v, setV] = useState(initialValue);
+  return (
+    <input
+      style={{
+        border: 0,
+        width: "95%",
+        fontSize: 12,
+        background: "none"
+      }}
+      ref={r => {
+        if (shouldSelectAll && r) {
+          r?.select();
+          stopSelectAll();
+        }
+      }}
+      {...dataTest}
+      type={isNumeric ? "number" : undefined}
+      value={v}
+      autoFocus
+      onKeyDown={e => {
+        if (e.key === "Enter") {
+          finishEdit(v);
+          e.stopPropagation();
+        } else if (e.key === "Escape") {
+          e.stopPropagation();
+          cancelEdit();
+        }
+      }}
+      onBlur={() => {
+        finishEdit(v);
+      }}
+      onChange={e => {
+        setV(e.target.value);
+      }}
+    />
+  );
+};

--- a/packages/ui/src/DataTable/EditabelCell.js
+++ b/packages/ui/src/DataTable/EditabelCell.js
@@ -1,15 +1,31 @@
-import React, { useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 
 export const EditableCell = ({
-  shouldSelectAll,
-  stopSelectAll,
-  initialValue,
-  finishEdit,
   cancelEdit,
+  dataTest,
+  finishEdit,
+  initialValue,
+  isEditableCellInitialValue,
   isNumeric,
-  dataTest
+  shouldSelectAll,
+  stopSelectAll
 }) => {
-  const [v, setV] = useState(initialValue);
+  const [value, setValue] = useState(initialValue);
+  const inputRef = useRef(null);
+
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.focus();
+      if (isEditableCellInitialValue && !isNumeric) {
+        inputRef.current.selectionStart = inputRef.current.value.length;
+        inputRef.current.selectionEnd = inputRef.current.value.length;
+      } else if (shouldSelectAll) {
+        inputRef.current.select();
+        stopSelectAll();
+      }
+    }
+  }, [isEditableCellInitialValue, isNumeric, shouldSelectAll, stopSelectAll]);
+
   return (
     <input
       style={{
@@ -18,31 +34,22 @@ export const EditableCell = ({
         fontSize: 12,
         background: "none"
       }}
-      ref={r => {
-        if (shouldSelectAll && r) {
-          r?.select();
-          stopSelectAll();
-        }
-      }}
+      ref={inputRef}
       {...dataTest}
-      type={isNumeric ? "number" : undefined}
-      value={v}
       autoFocus
       onKeyDown={e => {
         if (e.key === "Enter") {
-          finishEdit(v);
+          finishEdit(value);
           e.stopPropagation();
         } else if (e.key === "Escape") {
           e.stopPropagation();
           cancelEdit();
         }
       }}
-      onBlur={() => {
-        finishEdit(v);
-      }}
-      onChange={e => {
-        setV(e.target.value);
-      }}
+      onBlur={() => finishEdit(value)}
+      onChange={e => setValue(e.target.value)}
+      type={isNumeric ? "number" : undefined}
+      value={value}
     />
   );
 };

--- a/packages/ui/src/DataTable/PagingTool.js
+++ b/packages/ui/src/DataTable/PagingTool.js
@@ -5,7 +5,7 @@ import { noop, get, toInteger } from "lodash-es";
 import { Button, Classes } from "@blueprintjs/core";
 import { onEnterOrBlurHelper } from "../utils/handlerHelpers";
 import { defaultPageSizes } from "./utils/queryParams";
-import getIdOrCodeOrIndex from "./utils/getIdOrCodeOrIndex";
+import { getIdOrCodeOrIndex } from "./utils";
 
 function PagingInput({ disabled, onBlur, defaultPage }) {
   const [page, setPage] = useState(defaultPage);

--- a/packages/ui/src/DataTable/utils/formatPasteData.js
+++ b/packages/ui/src/DataTable/utils/formatPasteData.js
@@ -1,0 +1,16 @@
+import { getFieldPathToField } from "./getFieldPathToField";
+
+export const formatPasteData = ({ schema, newVal, path }) => {
+  const pathToField = getFieldPathToField(schema);
+  const column = pathToField[path];
+  if (column.type === "genericSelect") {
+    if (newVal?.__genSelCol === path) {
+      newVal = newVal.__strVal;
+    } else {
+      newVal = undefined;
+    }
+  } else {
+    newVal = Object.hasOwn(newVal, "__strVal") ? newVal.__strVal : newVal;
+  }
+  return newVal;
+};

--- a/packages/ui/src/DataTable/utils/getAllRows.js
+++ b/packages/ui/src/DataTable/utils/getAllRows.js
@@ -1,0 +1,11 @@
+export const getAllRows = e => {
+  const el = e.target.querySelector(".data-table-container")
+    ? e.target.querySelector(".data-table-container")
+    : e.target.closest(".data-table-container");
+
+  const allRowEls = el.querySelectorAll(".rt-tr");
+  if (!allRowEls || !allRowEls.length) {
+    return;
+  }
+  return allRowEls;
+};

--- a/packages/ui/src/DataTable/utils/getCellCopyText.js
+++ b/packages/ui/src/DataTable/utils/getCellCopyText.js
@@ -1,0 +1,7 @@
+export const getCellCopyText = cellWrapper => {
+  const text = cellWrapper && cellWrapper.getAttribute("data-copy-text");
+  const jsonText = cellWrapper && cellWrapper.getAttribute("data-copy-json");
+
+  const textContent = text || cellWrapper.textContent || "";
+  return [textContent, jsonText];
+};

--- a/packages/ui/src/DataTable/utils/getCellInfo.js
+++ b/packages/ui/src/DataTable/utils/getCellInfo.js
@@ -1,0 +1,36 @@
+import { getIdOrCodeOrIndex } from "./getIdOrCodeOrIndex";
+
+export const getCellInfo = ({
+  columnIndex,
+  columnPath,
+  rowId,
+  schema,
+  entities,
+  rowIndex,
+  isEntityDisabled,
+  entity
+}) => {
+  const leftpath = schema.fields[columnIndex - 1]?.path;
+  const rightpath = schema.fields[columnIndex + 1]?.path;
+  const cellIdToLeft = leftpath && `${rowId}:${leftpath}`;
+  const cellIdToRight = rightpath && `${rowId}:${rightpath}`;
+  const rowAboveId =
+    entities[rowIndex - 1] &&
+    getIdOrCodeOrIndex(entities[rowIndex - 1], rowIndex - 1);
+  const rowBelowId =
+    entities[rowIndex + 1] &&
+    getIdOrCodeOrIndex(entities[rowIndex + 1], rowIndex + 1);
+  const cellIdAbove = rowAboveId && `${rowAboveId}:${columnPath}`;
+  const cellIdBelow = rowBelowId && `${rowBelowId}:${columnPath}`;
+
+  const cellId = `${rowId}:${columnPath}`;
+  const rowDisabled = isEntityDisabled(entity);
+  return {
+    cellId,
+    cellIdAbove,
+    cellIdToRight,
+    cellIdBelow,
+    cellIdToLeft,
+    rowDisabled
+  };
+};

--- a/packages/ui/src/DataTable/utils/getFieldPathToField.js
+++ b/packages/ui/src/DataTable/utils/getFieldPathToField.js
@@ -1,0 +1,7 @@
+export const getFieldPathToField = schema => {
+  const fieldPathToField = {};
+  schema.fields.forEach(f => {
+    fieldPathToField[f.path] = f;
+  });
+  return fieldPathToField;
+};

--- a/packages/ui/src/DataTable/utils/getIdOrCodeOrIndex.js
+++ b/packages/ui/src/DataTable/utils/getIdOrCodeOrIndex.js
@@ -1,4 +1,4 @@
-export default (record, rowIndex) => {
+export const getIdOrCodeOrIndex = (record, rowIndex) => {
   if (record.id || record.id === 0) {
     return record.id;
   } else if (record.code) {

--- a/packages/ui/src/DataTable/utils/getLastSelectedEntity.js
+++ b/packages/ui/src/DataTable/utils/getLastSelectedEntity.js
@@ -1,7 +1,7 @@
 export const getLastSelectedEntity = idMap => {
   let lastSelectedEnt;
   let latestTime;
-  idMap.forEach(({ time, entity }) => {
+  Object.values(idMap).forEach(({ time, entity }) => {
     if (!latestTime || time > latestTime) {
       lastSelectedEnt = entity;
       latestTime = time;

--- a/packages/ui/src/DataTable/utils/getLastSelectedEntity.js
+++ b/packages/ui/src/DataTable/utils/getLastSelectedEntity.js
@@ -1,0 +1,11 @@
+export const getLastSelectedEntity = idMap => {
+  let lastSelectedEnt;
+  let latestTime;
+  idMap.forEach(({ time, entity }) => {
+    if (!latestTime || time > latestTime) {
+      lastSelectedEnt = entity;
+      latestTime = time;
+    }
+  });
+  return lastSelectedEnt;
+};

--- a/packages/ui/src/DataTable/utils/getNewEntToSelect.js
+++ b/packages/ui/src/DataTable/utils/getNewEntToSelect.js
@@ -1,0 +1,25 @@
+export const getNewEntToSelect = ({
+  type,
+  lastSelectedIndex,
+  entities,
+  isEntityDisabled
+}) => {
+  let newIndexToSelect;
+  if (type === "up") {
+    newIndexToSelect = lastSelectedIndex - 1;
+  } else {
+    newIndexToSelect = lastSelectedIndex + 1;
+  }
+  const newEntToSelect = entities[newIndexToSelect];
+  if (!newEntToSelect) return;
+  if (isEntityDisabled && isEntityDisabled(newEntToSelect)) {
+    return getNewEntToSelect({
+      type,
+      lastSelectedIndex: newIndexToSelect,
+      entities,
+      isEntityDisabled
+    });
+  } else {
+    return newEntToSelect;
+  }
+};

--- a/packages/ui/src/DataTable/utils/getRowCopyText.js
+++ b/packages/ui/src/DataTable/utils/getRowCopyText.js
@@ -1,0 +1,28 @@
+import { getCellCopyText } from "./getCellCopyText";
+import { flatMap } from "lodash-es";
+
+export const getRowCopyText = (rowEl, { specificColumn } = {}) => {
+  //takes in a row element
+  if (!rowEl) return [];
+  const textContent = [];
+  const jsonText = [];
+
+  rowEl.children.forEach(cellEl => {
+    const cellChild = cellEl.querySelector(`[data-copy-text]`);
+    if (!cellChild) {
+      if (specificColumn) return []; //strip it
+      return; //just leave it blank
+    }
+    if (
+      specificColumn &&
+      cellChild.getAttribute("data-test") !== specificColumn
+    ) {
+      return [];
+    }
+    const [t, j] = getCellCopyText(cellChild);
+    textContent.push(t);
+    jsonText.push(j);
+  });
+
+  return [flatMap(textContent).join("\t"), jsonText];
+};

--- a/packages/ui/src/DataTable/utils/getRowCopyText.js
+++ b/packages/ui/src/DataTable/utils/getRowCopyText.js
@@ -7,22 +7,22 @@ export const getRowCopyText = (rowEl, { specificColumn } = {}) => {
   const textContent = [];
   const jsonText = [];
 
-  rowEl.children.forEach(cellEl => {
+  for (const cellEl of rowEl.children) {
     const cellChild = cellEl.querySelector(`[data-copy-text]`);
     if (!cellChild) {
-      if (specificColumn) return []; //strip it
-      return; //just leave it blank
+      if (specificColumn) continue; //strip it
+      continue; //just leave it blank
     }
     if (
       specificColumn &&
       cellChild.getAttribute("data-test") !== specificColumn
     ) {
-      return [];
+      continue;
     }
     const [t, j] = getCellCopyText(cellChild);
     textContent.push(t);
     jsonText.push(j);
-  });
+  }
 
   return [flatMap(textContent).join("\t"), jsonText];
 };

--- a/packages/ui/src/DataTable/utils/handleCopyColumn.js
+++ b/packages/ui/src/DataTable/utils/handleCopyColumn.js
@@ -1,0 +1,21 @@
+import { getAllRows } from "./getAllRows";
+import getIdOrCodeOrIndex from "./getIdOrCodeOrIndex";
+import { handleCopyRows } from "./handleCopyRows";
+
+export const handleCopyColumn = (e, cellWrapper, selectedRecords) => {
+  const specificColumn = cellWrapper.getAttribute("data-test");
+  let rowElsToCopy = getAllRows(e);
+  if (!rowElsToCopy) return;
+  if (selectedRecords) {
+    const ids = selectedRecords.map(e => getIdOrCodeOrIndex(e)?.toString());
+    rowElsToCopy = Array.from(rowElsToCopy).filter(rowEl => {
+      const id = rowEl.closest(".rt-tr-group")?.getAttribute("data-test-id");
+      return id !== undefined && ids.includes(id);
+    });
+  }
+  if (!rowElsToCopy) return;
+  handleCopyRows(rowElsToCopy, {
+    specificColumn,
+    onFinishMsg: "Column Copied"
+  });
+};

--- a/packages/ui/src/DataTable/utils/handleCopyColumn.js
+++ b/packages/ui/src/DataTable/utils/handleCopyColumn.js
@@ -1,5 +1,5 @@
 import { getAllRows } from "./getAllRows";
-import getIdOrCodeOrIndex from "./getIdOrCodeOrIndex";
+import { getIdOrCodeOrIndex } from "./getIdOrCodeOrIndex";
 import { handleCopyRows } from "./handleCopyRows";
 
 export const handleCopyColumn = (e, cellWrapper, selectedRecords) => {

--- a/packages/ui/src/DataTable/utils/handleCopyHelper.js
+++ b/packages/ui/src/DataTable/utils/handleCopyHelper.js
@@ -1,0 +1,15 @@
+import copy from "copy-to-clipboard";
+
+export const handleCopyHelper = (stringToCopy, jsonToCopy, message) => {
+  !window.Cypress &&
+    copy(stringToCopy, {
+      onCopy: clipboardData => {
+        clipboardData.setData("application/json", JSON.stringify(jsonToCopy));
+      },
+      // keep this so that pasting into spreadsheets works.
+      format: "text/plain"
+    });
+  if (message) {
+    window.toastr.success(message);
+  }
+};

--- a/packages/ui/src/DataTable/utils/handleCopyRows.js
+++ b/packages/ui/src/DataTable/utils/handleCopyRows.js
@@ -1,0 +1,23 @@
+import download from "downloadjs";
+import { getRowCopyText } from "./getRowCopyText";
+import { handleCopyHelper } from "./handleCopyHelper";
+
+export const handleCopyRows = (
+  rowElsToCopy,
+  { specificColumn, onFinishMsg, isDownload } = {}
+) => {
+  let textToCopy = [];
+  const jsonToCopy = [];
+  rowElsToCopy.forEach(rowEl => {
+    const [t, j] = getRowCopyText(rowEl, { specificColumn });
+    textToCopy.push(t);
+    jsonToCopy.push(j);
+  });
+  textToCopy = textToCopy.filter(text => text).join("\n");
+  if (!textToCopy) return window.toastr.warning("No text to copy");
+  if (isDownload) {
+    download(textToCopy.replaceAll("\t", ","), "tableData.csv", "text/csv");
+  } else {
+    handleCopyHelper(textToCopy, jsonToCopy, onFinishMsg || "Row Copied");
+  }
+};

--- a/packages/ui/src/DataTable/utils/index.js
+++ b/packages/ui/src/DataTable/utils/index.js
@@ -1,0 +1,51 @@
+import { isEntityClean } from "./isEntityClean";
+import { getSelectedRowsFromEntities } from "./selection";
+import { removeCleanRows } from "./removeCleanRows";
+import getIdOrCodeOrIndex from "./getIdOrCodeOrIndex";
+import computePresets from "./computePresets";
+import { getRecordsFromIdMap } from "./withSelectedEntities";
+import { formatPasteData } from "./formatPasteData";
+import { getFieldPathToField } from "./getFieldPathToField";
+import {
+  defaultParsePaste,
+  getEntityIdToEntity,
+  getFieldPathToIndex,
+  getNumberStrAtEnd,
+  stripNumberAtEnd
+} from "./utils";
+import { getAllRows } from "./getAllRows";
+import { getNewEntToSelect } from "./getNewEntToSelect";
+import { getLastSelectedEntity } from "./getLastSelectedEntity";
+import { getCellInfo } from "./getCellInfo";
+import { getCellCopyText } from "./getCellCopyText";
+import { getRowCopyText } from "./getRowCopyText";
+import { handleCopyHelper } from "./handleCopyHelper";
+import { handleCopyRows } from "./handleCopyRows";
+import { handleCopyColumn } from "./handleCopyColumn";
+import { isBottomRightCornerOfRectangle } from "./isBottomRightCornerOfRectangle";
+
+export {
+  computePresets,
+  defaultParsePaste,
+  formatPasteData,
+  getAllRows,
+  getCellCopyText,
+  getCellInfo,
+  getEntityIdToEntity,
+  getFieldPathToIndex,
+  getFieldPathToField,
+  getIdOrCodeOrIndex,
+  getLastSelectedEntity,
+  getNewEntToSelect,
+  getNumberStrAtEnd,
+  getRecordsFromIdMap,
+  getRowCopyText,
+  getSelectedRowsFromEntities,
+  handleCopyColumn,
+  handleCopyHelper,
+  handleCopyRows,
+  isBottomRightCornerOfRectangle,
+  isEntityClean,
+  removeCleanRows,
+  stripNumberAtEnd
+};

--- a/packages/ui/src/DataTable/utils/index.js
+++ b/packages/ui/src/DataTable/utils/index.js
@@ -1,7 +1,7 @@
 import { isEntityClean } from "./isEntityClean";
 import { getSelectedRowsFromEntities } from "./selection";
 import { removeCleanRows } from "./removeCleanRows";
-import getIdOrCodeOrIndex from "./getIdOrCodeOrIndex";
+import { getIdOrCodeOrIndex } from "./getIdOrCodeOrIndex";
 import computePresets from "./computePresets";
 import { getRecordsFromIdMap } from "./withSelectedEntities";
 import { formatPasteData } from "./formatPasteData";

--- a/packages/ui/src/DataTable/utils/isBottomRightCornerOfRectangle.js
+++ b/packages/ui/src/DataTable/utils/isBottomRightCornerOfRectangle.js
@@ -1,0 +1,20 @@
+export const isBottomRightCornerOfRectangle = ({
+  cellId,
+  selectionGrid,
+  lastRowIndex,
+  lastCellIndex,
+  entityMap,
+  pathToIndex
+}) => {
+  selectionGrid.forEach(row => {
+    // remove undefineds from start of row
+    while (row[0] === undefined && row.length) row.shift();
+  });
+  const [rowId, cellPath] = cellId.split(":");
+  const ent = entityMap[rowId];
+  if (!ent) return;
+  const { i } = ent;
+  const cellIndex = pathToIndex[cellPath];
+  const isBottomRight = i === lastRowIndex && cellIndex === lastCellIndex;
+  return isBottomRight;
+};

--- a/packages/ui/src/DataTable/utils/isEntityClean.js
+++ b/packages/ui/src/DataTable/utils/isEntityClean.js
@@ -1,13 +1,15 @@
 export function isEntityClean(e) {
+  if (typeof e !== "object" || e === null) {
+    return true; // or return false depending on what you want for non-object inputs
+  }
   let isClean = true;
-  e.some((val, key) => {
-    if (key === "id") return false;
-    if (key === "_isClean") return false;
+  for (const [key, val] of Object.entries(e)) {
+    if (key === "id") continue;
+    if (key === "_isClean") continue;
     if (val) {
       isClean = false;
-      return true;
+      break;
     }
-    return false;
-  });
+  }
   return isClean;
 }

--- a/packages/ui/src/DataTable/utils/isEntityClean.js
+++ b/packages/ui/src/DataTable/utils/isEntityClean.js
@@ -1,0 +1,13 @@
+export function isEntityClean(e) {
+  let isClean = true;
+  e.some((val, key) => {
+    if (key === "id") return false;
+    if (key === "_isClean") return false;
+    if (val) {
+      isClean = false;
+      return true;
+    }
+    return false;
+  });
+  return isClean;
+}

--- a/packages/ui/src/DataTable/utils/removeCleanRows.js
+++ b/packages/ui/src/DataTable/utils/removeCleanRows.js
@@ -1,0 +1,22 @@
+import { isEntityClean } from "./isEntityClean";
+import { getIdOrCodeOrIndex } from "./getIdOrCodeOrIndex";
+
+export function removeCleanRows(reduxFormEntities, reduxFormCellValidation) {
+  const toFilterOut = {};
+  const entsToUse = (reduxFormEntities || []).filter(e => {
+    if (!(e._isClean || isEntityClean(e))) return true;
+    else {
+      toFilterOut[getIdOrCodeOrIndex(e)] = true;
+      return false;
+    }
+  });
+
+  const validationToUse = {};
+  reduxFormCellValidation.forEach((v, k) => {
+    const [rowId] = k.split(":");
+    if (!toFilterOut[rowId]) {
+      validationToUse[k] = v;
+    }
+  });
+  return { entsToUse, validationToUse };
+}

--- a/packages/ui/src/DataTable/utils/removeCleanRows.js
+++ b/packages/ui/src/DataTable/utils/removeCleanRows.js
@@ -1,7 +1,7 @@
 import { isEntityClean } from "./isEntityClean";
 import { getIdOrCodeOrIndex } from "./getIdOrCodeOrIndex";
 
-export function removeCleanRows(reduxFormEntities, reduxFormCellValidation) {
+export const removeCleanRows = (reduxFormEntities, reduxFormCellValidation) => {
   const toFilterOut = {};
   const entsToUse = (reduxFormEntities || []).filter(e => {
     if (!(e._isClean || isEntityClean(e))) return true;
@@ -12,11 +12,11 @@ export function removeCleanRows(reduxFormEntities, reduxFormCellValidation) {
   });
 
   const validationToUse = {};
-  reduxFormCellValidation.forEach((v, k) => {
+  Object.entries(reduxFormCellValidation || {}).forEach(([k, v]) => {
     const [rowId] = k.split(":");
     if (!toFilterOut[rowId]) {
       validationToUse[k] = v;
     }
   });
   return { entsToUse, validationToUse };
-}
+};

--- a/packages/ui/src/DataTable/utils/rowClick.js
+++ b/packages/ui/src/DataTable/utils/rowClick.js
@@ -124,8 +124,10 @@ export function changeSelectedEntities({ idMap, entities = [], change }) {
   change("reduxFormSelectedEntityIdMap", newIdMap);
 }
 
-export function finalizeSelection({ idMap, entities, props }) {
-  const {
+export function finalizeSelection({
+  idMap,
+  entities,
+  props: {
     onDeselect,
     onSingleRowSelect,
     onMultiRowSelect,
@@ -133,7 +135,8 @@ export function finalizeSelection({ idMap, entities, props }) {
     onRowSelect,
     noSelect,
     change
-  } = props;
+  }
+}) {
   if (noSelect) return;
   if (
     noDeselectAll &&

--- a/packages/ui/src/DataTable/utils/rowClick.js
+++ b/packages/ui/src/DataTable/utils/rowClick.js
@@ -1,6 +1,6 @@
 import { isEmpty, forEach, range } from "lodash-es";
 import { getSelectedRowsFromEntities } from "./selection";
-import getIdOrCodeOrIndex from "./getIdOrCodeOrIndex";
+import { getIdOrCodeOrIndex } from "./getIdOrCodeOrIndex";
 import { getRecordsFromIdMap } from "./withSelectedEntities";
 
 export default function rowClick(e, rowInfo, entities, props) {

--- a/packages/ui/src/DataTable/utils/selection.js
+++ b/packages/ui/src/DataTable/utils/selection.js
@@ -1,4 +1,4 @@
-import getIdOrCodeOrIndex from "./getIdOrCodeOrIndex";
+import { getIdOrCodeOrIndex } from "./getIdOrCodeOrIndex";
 
 export const getSelectedRowsFromEntities = (entities, idMap) => {
   if (!idMap) return [];

--- a/packages/ui/src/DataTable/utils/utils.js
+++ b/packages/ui/src/DataTable/utils/utils.js
@@ -1,0 +1,37 @@
+import getIdOrCodeOrIndex from "./getIdOrCodeOrIndex";
+
+export const getFieldPathToIndex = schema => {
+  const fieldToIndex = {};
+  schema.fields.forEach((f, i) => {
+    fieldToIndex[f.path] = i;
+  });
+  return fieldToIndex;
+};
+
+export const defaultParsePaste = str => {
+  return str.split(/\r\n|\n|\r/).map(row => row.split("\t"));
+};
+
+export const getEntityIdToEntity = entities => {
+  const entityIdToEntity = {};
+  entities.forEach((e, i) => {
+    entityIdToEntity[getIdOrCodeOrIndex(e, i)] = { e, i };
+  });
+  return entityIdToEntity;
+};
+
+const endsWithNumber = str => {
+  return /[0-9]+$/.test(str);
+};
+
+export const getNumberStrAtEnd = str => {
+  if (endsWithNumber(str)) {
+    return str.match(/[0-9]+$/)[0];
+  }
+
+  return null;
+};
+
+export const stripNumberAtEnd = str => {
+  return str?.replace?.(getNumberStrAtEnd(str), "");
+};

--- a/packages/ui/src/DataTable/utils/utils.js
+++ b/packages/ui/src/DataTable/utils/utils.js
@@ -1,4 +1,4 @@
-import getIdOrCodeOrIndex from "./getIdOrCodeOrIndex";
+import { getIdOrCodeOrIndex } from "./getIdOrCodeOrIndex";
 
 export const getFieldPathToIndex = schema => {
   const fieldToIndex = {};

--- a/packages/ui/src/DataTable/validateTableWideErrors.js
+++ b/packages/ui/src/DataTable/validateTableWideErrors.js
@@ -1,4 +1,4 @@
-import getIdOrCodeOrIndex from "./utils/getIdOrCodeOrIndex";
+import { getIdOrCodeOrIndex } from "./utils";
 import { getCellVal } from "./getCellVal";
 import { forEach, isArray } from "lodash-es";
 import { startCase } from "lodash-es";

--- a/packages/ui/src/FillWindow.js
+++ b/packages/ui/src/FillWindow.js
@@ -1,6 +1,5 @@
-import React from "react";
+import React, { createPortal } from "react";
 import { isFunction } from "lodash-es";
-import reactDom from "react-dom";
 import rerenderOnWindowResize from "./rerenderOnWindowResize";
 import "./FillWindow.css";
 
@@ -63,7 +62,7 @@ export default class FillWindow extends React.Component {
           : this.props.children}
       </div>
     );
-    if (asPortal) return reactDom.createPortal(inner, window.document.body);
+    if (asPortal) return createPortal(inner, window.document.body);
     return inner;
   }
 }

--- a/packages/ui/src/FormComponents/Uploader.js
+++ b/packages/ui/src/FormComponents/Uploader.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import {
   Button,
   Callout,
@@ -16,7 +16,6 @@ import classnames from "classnames";
 import { nanoid } from "nanoid";
 import papaparse, { unparse } from "papaparse";
 import downloadjs from "downloadjs";
-import { configure, makeObservable, observable } from "mobx";
 import { observer } from "mobx-react";
 import UploadCsvWizardDialog, {
   SimpleInsertDataDialog
@@ -30,7 +29,7 @@ import {
   removeExt
 } from "@teselagen/file-utils";
 import tryToMatchSchemas from "./tryToMatchSchemas";
-import { forEach, isArray, isFunction, isPlainObject, noop } from "lodash-es";
+import { isArray, isFunction, isPlainObject, noop } from "lodash-es";
 import { flatMap } from "lodash-es";
 import urljoin from "url-join";
 import popoverOverflowModifiers from "../utils/popoverOverflowModifiers";
@@ -38,14 +37,12 @@ import writeXlsxFile from "write-excel-file";
 import { startCase } from "lodash-es";
 import { getNewName } from "./getNewName";
 import { isObject } from "lodash-es";
-import { connect } from "react-redux";
+import { useDispatch } from "react-redux";
 import { initialize } from "redux-form";
 import classNames from "classnames";
-import { compose } from "recompose";
 import convertSchema from "../DataTable/utils/convertSchema";
 import { LoadingDots } from "./LoadingDots";
 
-configure({ isolateGlobalState: true });
 const helperText = [
   `How to Use This Template to Upload New Data`,
   `1. Go to the first tab and delete the example data.`,
@@ -64,58 +61,106 @@ const helperSchema = [
   }
 ];
 
-class ValidateAgainstSchema {
-  fields = [];
-
-  constructor() {
-    makeObservable(this, {
-      fields: observable.shallow
-    });
+const setValidateAgainstSchema = newValidateAgainstSchema => {
+  if (!newValidateAgainstSchema) return { fields: [] };
+  const schema = convertSchema(newValidateAgainstSchema);
+  if (
+    schema.fields.some(f => {
+      if (f.path === "id") {
+        return true;
+      }
+      return false;
+    })
+  ) {
+    throw new Error(
+      `Uploader was passed a validateAgainstSchema with a fields array that contains a field with a path of "id". This is not allowed.`
+    );
   }
+  return schema;
+};
 
-  setValidateAgainstSchema(newValidateAgainstSchema) {
-    if (!newValidateAgainstSchema) {
-      this.fields = [];
-      return;
-    }
-    const schema = convertSchema(newValidateAgainstSchema);
-    if (
-      schema.fields.some(f => {
-        if (f.path === "id") {
-          return true;
-        }
-        return false;
-      })
-    ) {
-      throw new Error(
-        `Uploader was passed a validateAgainstSchema with a fields array that contains a field with a path of "id". This is not allowed.`
-      );
-    }
-    forEach(schema, (v, k) => {
-      this[k] = v;
-    });
-  }
-}
+const InnerDropZone = ({
+  getRootProps,
+  getInputProps,
+  isDragAccept,
+  isDragReject,
+  isDragActive,
+  className,
+  minimal,
+  dropzoneDisabled,
+  contentOverride,
+  simpleAccept,
+  innerIcon,
+  innerText,
+  validateAgainstSchema,
+  handleManuallyEnterData,
+  noBuildCsvOption,
+  showFilesCount,
+  fileList
+  // isDragActive
+  // isDragReject
+  // isDragAccept
+}) => (
+  <section>
+    <div
+      {...getRootProps()}
+      className={classnames("tg-dropzone", className, {
+        "tg-dropzone-minimal": minimal,
+        "tg-dropzone-active": isDragActive,
+        "tg-dropzone-reject": isDragReject, // tnr: the acceptClassName/rejectClassName doesn't work with file extensions (only mimetypes are supported when dragging). Thus we'll just always turn the drop area blue when dragging and let the filtering occur on drop. See https://github.com/react-dropzone/react-dropzone/issues/888#issuecomment-773938074
+        "tg-dropzone-accept": isDragAccept,
+        "tg-dropzone-disabled": dropzoneDisabled,
+        "bp3-disabled": dropzoneDisabled
+      })}
+    >
+      <input {...getInputProps()} />
+      {contentOverride || (
+        <div
+          title={
+            simpleAccept
+              ? "Accepts only the following file types: " + simpleAccept
+              : "Accepts any file input"
+          }
+          className="tg-upload-inner"
+        >
+          {innerIcon || <Icon icon="upload" iconSize={minimal ? 15 : 30} />}
+          {innerText || (minimal ? "Upload" : "Click or drag to upload")}
+          {validateAgainstSchema && !noBuildCsvOption && (
+            <div
+              style={{
+                textAlign: "center",
+                // fontSize: 18,
+                marginTop: 7,
+                marginBottom: 5
+              }}
+              onClick={handleManuallyEnterData}
+              className="link-button"
+            >
+              ...or {manualEnterMessage}
+              {/* <div
+                style={{
+                  fontSize: 11,
+                  color: Colors.GRAY3,
+                  fontStyle: "italic"
+                }}
+              >
+                {manualEnterSubMessage}
+              </div> */}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
 
-// autorun(() => {
-//   console.log(
-//     `validateAgainstSchemaStore?.fields:`,
-//     JSON.stringify(validateAgainstSchemaStore?.fields, null, 4)
-//   );
-// });
-// validateAgainstSchemaStore.fields = ["hahah"];
-// validateAgainstSchemaStore.fields.push("yaa");
+    {showFilesCount ? (
+      <div className="tg-upload-file-list-counter">
+        Files: {fileList ? fileList.length : 0}
+      </div>
+    ) : null}
+  </section>
+);
 
-// const validateAgainstSchema = observable.shallow({
-//   fields: []
-// })
-
-// validateAgainstSchema.fields = ["hahah"];
-
-// wink wink
-const emptyPromise = Promise.resolve.bind(Promise);
-
-function UploaderInner({
+const UploaderInner = ({
   accept: __accept,
   contentOverride: maybeContentOverride,
   innerIcon,
@@ -130,7 +175,9 @@ function UploaderInner({
   showUploadList = true,
   beforeUpload,
   fileList, //list of files with options: {name, loading, error, url, originalName, downloadName}
-  onFileSuccess = emptyPromise, //called each time a file is finished and before the file.loading gets set to false, needs to return a promise!
+  onFileSuccess = async () => {
+    return;
+  }, //called each time a file is finished and before the file.loading gets set to false, needs to return a promise!
   onFieldSubmit = noop, //called when all files have successfully uploaded
   // fileFinished = noop,
   onRemove = noop, //called when a file has been selected to be removed
@@ -141,22 +188,27 @@ function UploaderInner({
   autoUnzip,
   disabled: _disabled,
   noBuildCsvOption,
-  initializeForm,
   showFilesCount,
   threeDotMenuItems,
   onPreviewClick
-}) {
+}) => {
+  const dispatch = useDispatch();
   let dropzoneDisabled = _disabled;
   let _accept = __accept;
-  const validateAgainstSchemaStore = useRef(new ValidateAgainstSchema());
   const [acceptLoading, setAcceptLoading] = useState();
   const [resolvedAccept, setResolvedAccept] = useState();
+
   if (resolvedAccept) {
     _accept = resolvedAccept;
   }
-  const isAcceptPromise =
-    __accept?.then ||
-    (Array.isArray(__accept) ? __accept.some(a => a?.then) : false);
+
+  const isAcceptPromise = useMemo(
+    () =>
+      __accept?.then ||
+      (Array.isArray(__accept) ? __accept.some(a => a?.then) : false),
+    [__accept]
+  );
+
   useEffect(() => {
     if (isAcceptPromise) {
       setAcceptLoading(true);
@@ -169,35 +221,36 @@ function UploaderInner({
       );
     }
   }, [__accept, isAcceptPromise]);
+
   if (isAcceptPromise && !resolvedAccept) {
     _accept = [];
   }
+
   if (acceptLoading) dropzoneDisabled = true;
-  const accept = !_accept
-    ? undefined
-    : isAcceptPromise && !resolvedAccept
-      ? []
-      : isPlainObject(_accept)
-        ? [_accept]
-        : isArray(_accept)
-          ? _accept
-          : _accept.split(",").map(a => ({ type: a }));
+  const accept = useMemo(
+    () =>
+      !_accept
+        ? undefined
+        : isAcceptPromise && !resolvedAccept
+          ? []
+          : isPlainObject(_accept)
+            ? [_accept]
+            : isArray(_accept)
+              ? _accept
+              : _accept.split(",").map(a => ({ type: a })),
+    [_accept, isAcceptPromise, resolvedAccept]
+  );
+
   const callout = _callout || accept?.find?.(a => a?.callout)?.callout;
 
-  const validateAgainstSchemaToUse =
-    _validateAgainstSchema ||
-    accept?.find?.(a => a?.validateAgainstSchema)?.validateAgainstSchema;
-
-  useEffect(() => {
-    // validateAgainstSchema
-    validateAgainstSchemaStore.current.setValidateAgainstSchema(
-      validateAgainstSchemaToUse
-    );
-  }, [validateAgainstSchemaToUse]);
-  let validateAgainstSchema;
-  if (validateAgainstSchemaToUse) {
-    validateAgainstSchema = validateAgainstSchemaStore.current;
-  }
+  const validateAgainstSchema = useMemo(
+    () =>
+      setValidateAgainstSchema(
+        _validateAgainstSchema ||
+          accept?.find?.(a => a?.validateAgainstSchema)?.validateAgainstSchema
+      ),
+    [_validateAgainstSchema, accept]
+  );
 
   if (
     (validateAgainstSchema || autoUnzip) &&
@@ -215,6 +268,7 @@ function UploaderInner({
   const { showDialogPromise: showUploadCsvWizardDialog, comp } = useDialog({
     ModalComponent: UploadCsvWizardDialog
   });
+
   const { showDialogPromise: showSimpleInsertDataDialog, comp: comp2 } =
     useDialog({
       ModalComponent: SimpleInsertDataDialog
@@ -553,7 +607,7 @@ function UploaderInner({
                                         }
                                         {...getFileDownloadAttr(exampleFile)}
                                         key={i}
-                                      ></MenuItem>
+                                      />
                                     );
                                   }
                                 )}
@@ -619,7 +673,7 @@ function UploaderInner({
                                 }}
                                 size={10}
                                 icon="download"
-                              ></Icon>
+                              />
                             )}
                           </CustomTag>
                         </PopOrTooltip>
@@ -631,7 +685,8 @@ function UploaderInner({
                 // make the dots below "load"
 
                 <>
-                  Accept Loading<LoadingDots></LoadingDots>
+                  Accept Loading
+                  <LoadingDots />
                 </>
               ) : (
                 <>Accepts {simpleAccept}</>
@@ -650,135 +705,135 @@ function UploaderInner({
                     .join(", ")
                 : undefined
             }
-            {...{
-              onDrop: async (_acceptedFiles, rejectedFiles) => {
-                let acceptedFiles = [];
-                for (const file of _acceptedFiles) {
-                  if ((validateAgainstSchema || autoUnzip) && isZipFile(file)) {
-                    const files = await filterFilesInZip(
-                      file,
-                      simpleAccept
-                        ?.split(", ")
-                        ?.map(a => (a.startsWith(".") ? a : "." + a)) || []
-                    );
-                    acceptedFiles.push(...files.map(f => f.originFileObj));
-                  } else {
-                    acceptedFiles.push(file);
-                  }
-                }
-                cleanupFiles();
-                if (rejectedFiles.length) {
-                  let msg = "";
-                  rejectedFiles.forEach(file => {
-                    if (msg) msg += "\n";
-                    msg +=
-                      `${file.file.name}: ` +
-                      file.errors.map(err => err.message).join(", ");
-                  });
-                  window.toastr &&
-                    window.toastr.warning(
-                      <div className="preserve-newline">{msg}</div>
-                    );
-                }
-                if (!acceptedFiles.length) return;
-                setLoading(true);
-                acceptedFiles = trimFiles(acceptedFiles, fileLimit);
-
-                acceptedFiles.forEach(file => {
-                  file.preview = URL.createObjectURL(file);
-                  file.loading = true;
-                  if (!file.id) {
-                    file.id = nanoid();
-                  }
-                  filesToClean.current.push(file);
-                });
-
-                if (readBeforeUpload) {
-                  acceptedFiles = await Promise.all(
-                    acceptedFiles.map(file => {
-                      return new Promise((resolve, reject) => {
-                        const reader = new FileReader();
-                        reader.readAsText(file, "UTF-8");
-                        reader.onload = evt => {
-                          file.parsedString = evt.target.result;
-                          resolve(file);
-                        };
-                        reader.onerror = err => {
-                          console.error("err:", err);
-                          reject(err);
-                        };
-                      });
-                    })
+            onDrop={async (_acceptedFiles, rejectedFiles) => {
+              let acceptedFiles = [];
+              for (const file of _acceptedFiles) {
+                if ((validateAgainstSchema || autoUnzip) && isZipFile(file)) {
+                  const files = await filterFilesInZip(
+                    file,
+                    simpleAccept
+                      ?.split(", ")
+                      ?.map(a => (a.startsWith(".") ? a : "." + a)) || []
                   );
+                  acceptedFiles.push(...files.map(f => f.originFileObj));
+                } else {
+                  acceptedFiles.push(file);
                 }
-                const cleanedAccepted = acceptedFiles.map(file => {
-                  return {
-                    originFileObj: file,
-                    originalFileObj: file,
-                    id: file.id,
-                    lastModified: file.lastModified,
-                    lastModifiedDate: file.lastModifiedDate,
-                    loading: file.loading,
-                    name: file.name,
-                    preview: file.preview,
-                    size: file.size,
-                    type: file.type,
-                    ...(file.parsedString
-                      ? { parsedString: file.parsedString }
-                      : {})
-                  };
+              }
+              cleanupFiles();
+              if (rejectedFiles.length) {
+                let msg = "";
+                rejectedFiles.forEach(file => {
+                  if (msg) msg += "\n";
+                  msg +=
+                    `${file.file.name}: ` +
+                    file.errors.map(err => err.message).join(", ");
                 });
+                window.toastr &&
+                  window.toastr.warning(
+                    <div className="preserve-newline">{msg}</div>
+                  );
+              }
+              if (!acceptedFiles.length) return;
+              setLoading(true);
+              acceptedFiles = trimFiles(acceptedFiles, fileLimit);
 
-                const toKeep = [];
-                if (validateAgainstSchema) {
-                  const filesWIssues = [];
-                  const filesWOIssues = [];
-                  for (const [i, file] of cleanedAccepted.entries()) {
-                    if (isCsvOrExcelFile(file)) {
-                      let parsedF;
-                      try {
-                        parsedF = await parseCsvOrExcelFile(file, {
-                          csvParserOptions: isFunction(
-                            validateAgainstSchema.csvParserOptions
-                          )
-                            ? validateAgainstSchema.csvParserOptions({
-                                validateAgainstSchema
-                              })
-                            : validateAgainstSchema.csvParserOptions
-                        });
-                      } catch (error) {
-                        console.error("error:", error);
-                        window.toastr &&
-                          window.toastr.error(
-                            `There was an error parsing your file. Please try again. ${
-                              error.message || error
-                            }`
-                          );
-                        return;
-                      }
+              acceptedFiles.forEach(file => {
+                file.preview = URL.createObjectURL(file);
+                file.loading = true;
+                if (!file.id) {
+                  file.id = nanoid();
+                }
+                filesToClean.current.push(file);
+              });
 
-                      const {
-                        csvValidationIssue: _csvValidationIssue,
-                        matchedHeaders,
-                        userSchema,
-                        searchResults,
-                        ignoredHeadersMsg
-                      } = await tryToMatchSchemas({
-                        incomingData: parsedF.data,
-                        validateAgainstSchema
+              if (readBeforeUpload) {
+                acceptedFiles = await Promise.all(
+                  acceptedFiles.map(file => {
+                    return new Promise((resolve, reject) => {
+                      const reader = new FileReader();
+                      reader.readAsText(file, "UTF-8");
+                      reader.onload = evt => {
+                        file.parsedString = evt.target.result;
+                        resolve(file);
+                      };
+                      reader.onerror = err => {
+                        console.error("err:", err);
+                        reject(err);
+                      };
+                    });
+                  })
+                );
+              }
+              const cleanedAccepted = acceptedFiles.map(file => {
+                return {
+                  originFileObj: file,
+                  originalFileObj: file,
+                  id: file.id,
+                  lastModified: file.lastModified,
+                  lastModifiedDate: file.lastModifiedDate,
+                  loading: file.loading,
+                  name: file.name,
+                  preview: file.preview,
+                  size: file.size,
+                  type: file.type,
+                  ...(file.parsedString
+                    ? { parsedString: file.parsedString }
+                    : {})
+                };
+              });
+
+              const toKeep = [];
+              if (validateAgainstSchema) {
+                const filesWIssues = [];
+                const filesWOIssues = [];
+                for (const [i, file] of cleanedAccepted.entries()) {
+                  if (isCsvOrExcelFile(file)) {
+                    let parsedF;
+                    try {
+                      parsedF = await parseCsvOrExcelFile(file, {
+                        csvParserOptions: isFunction(
+                          validateAgainstSchema.csvParserOptions
+                        )
+                          ? validateAgainstSchema.csvParserOptions({
+                              validateAgainstSchema
+                            })
+                          : validateAgainstSchema.csvParserOptions
                       });
-                      if (userSchema?.userData?.length === 0) {
-                        console.error(
-                          `userSchema, parsedF.data:`,
-                          userSchema,
-                          parsedF.data
+                    } catch (error) {
+                      console.error("error:", error);
+                      window.toastr &&
+                        window.toastr.error(
+                          `There was an error parsing your file. Please try again. ${
+                            error.message || error
+                          }`
                         );
-                      } else {
-                        toKeep.push(file);
-                        let csvValidationIssue = _csvValidationIssue;
-                        if (csvValidationIssue) {
-                          if (isObject(csvValidationIssue)) {
-                            initializeForm(
+                      return;
+                    }
+
+                    const {
+                      csvValidationIssue: _csvValidationIssue,
+                      matchedHeaders,
+                      userSchema,
+                      searchResults,
+                      ignoredHeadersMsg
+                    } = await tryToMatchSchemas({
+                      incomingData: parsedF.data,
+                      validateAgainstSchema
+                    });
+                    if (userSchema?.userData?.length === 0) {
+                      console.error(
+                        `userSchema, parsedF.data:`,
+                        userSchema,
+                        parsedF.data
+                      );
+                    } else {
+                      toKeep.push(file);
+                      let csvValidationIssue = _csvValidationIssue;
+                      if (csvValidationIssue) {
+                        if (isObject(csvValidationIssue)) {
+                          dispatch(
+                            initialize(
                               `editableCellTable${
                                 cleanedAccepted.length > 1 ? `-${i}` : ""
                               }`,
@@ -790,149 +845,142 @@ function UploaderInner({
                                 keepValues: true,
                                 updateUnregisteredFields: true
                               }
-                            );
-                            const err = Object.values(csvValidationIssue)[0];
-                            // csvValidationIssue = `It looks like there was an error with your data - \n\n${
-                            //   err && err.message ? err.message : err
-                            // }.\n\nPlease review your headers and then correct any errors on the next page.`; //pass just the first error as a string
-                            const errMsg =
-                              err && err.message ? err.message : err;
-                            if (isPlainObject(errMsg)) {
-                              throw new Error(
-                                `errMsg is an object ${JSON.stringify(
-                                  errMsg,
-                                  null,
-                                  4
-                                )}`
-                              );
-                            }
-                            csvValidationIssue = (
-                              <div>
-                                <div>
-                                  It looks like there was an error with your
-                                  data (Correct on the Review Data page):
-                                </div>
-                                <div style={{ color: "red" }}>{errMsg}</div>
-                                <div>
-                                  Please review your headers and then correct
-                                  any errors on the next page.
-                                </div>
-                              </div>
+                            )
+                          );
+                          const err = Object.values(csvValidationIssue)[0];
+                          // csvValidationIssue = `It looks like there was an error with your data - \n\n${
+                          //   err && err.message ? err.message : err
+                          // }.\n\nPlease review your headers and then correct any errors on the next page.`; //pass just the first error as a string
+                          const errMsg = err && err.message ? err.message : err;
+                          if (isPlainObject(errMsg)) {
+                            throw new Error(
+                              `errMsg is an object ${JSON.stringify(
+                                errMsg,
+                                null,
+                                4
+                              )}`
                             );
                           }
-                          filesWIssues.push({
-                            file,
-                            csvValidationIssue,
-                            ignoredHeadersMsg,
-                            matchedHeaders,
-                            userSchema,
-                            searchResults
-                          });
-                        } else {
-                          filesWOIssues.push({
-                            file,
-                            csvValidationIssue,
-                            ignoredHeadersMsg,
-                            matchedHeaders,
-                            userSchema,
-                            searchResults
-                          });
-                          const newFileName = removeExt(file.name) + `.csv`;
-
-                          const { newFile, cleanedEntities } = getNewCsvFile(
-                            userSchema.userData,
-                            newFileName
+                          csvValidationIssue = (
+                            <div>
+                              <div>
+                                It looks like there was an error with your data
+                                (Correct on the Review Data page):
+                              </div>
+                              <div style={{ color: "red" }}>{errMsg}</div>
+                              <div>
+                                Please review your headers and then correct any
+                                errors on the next page.
+                              </div>
+                            </div>
                           );
-
-                          file.meta = parsedF.meta;
-                          file.hasEditClick = true;
-                          file.parsedData = cleanedEntities;
-                          file.name = newFileName;
-                          file.originFileObj = newFile;
-                          file.originalFileObj = newFile;
                         }
-                      }
-                    } else {
-                      toKeep.push(file);
-                    }
-                  }
-                  if (filesWIssues.length) {
-                    const { file } = filesWIssues[0];
-                    const allFiles = [...filesWIssues, ...filesWOIssues];
-                    const doAllFilesHaveSameHeaders = allFiles.every(f => {
-                      if (f.userSchema.fields && f.userSchema.fields.length) {
-                        return f.userSchema.fields.every((h, i) => {
-                          return (
-                            h.path === allFiles[0].userSchema.fields[i].path
-                          );
+                        filesWIssues.push({
+                          file,
+                          csvValidationIssue,
+                          ignoredHeadersMsg,
+                          matchedHeaders,
+                          userSchema,
+                          searchResults
                         });
-                      }
-                      return false;
-                    });
-                    const multipleFiles = allFiles.length > 1;
-                    const { res } = await showUploadCsvWizardDialog(
-                      "onUploadWizardFinish",
-                      {
-                        dialogProps: {
-                          title: `Fix Up File${multipleFiles ? "s" : ""} ${
-                            multipleFiles
-                              ? ""
-                              : file.name
-                                ? `"${file.name}"`
-                                : ""
-                          }`
-                        },
-                        doAllFilesHaveSameHeaders,
-                        filesWIssues: allFiles,
-                        validateAgainstSchema
-                      }
-                    );
+                      } else {
+                        filesWOIssues.push({
+                          file,
+                          csvValidationIssue,
+                          ignoredHeadersMsg,
+                          matchedHeaders,
+                          userSchema,
+                          searchResults
+                        });
+                        const newFileName = removeExt(file.name) + `.csv`;
 
-                    if (!res) {
-                      window.toastr.warning(`File Upload Aborted`);
-                      return;
-                    } else {
-                      allFiles.forEach(({ file }, i) => {
-                        const newEntities = res[i];
-                        // const newFileName = removeExt(file.name) + `_updated.csv`;
-                        //swap out file with a new csv file
                         const { newFile, cleanedEntities } = getNewCsvFile(
-                          newEntities,
-                          file.name
+                          userSchema.userData,
+                          newFileName
                         );
 
+                        file.meta = parsedF.meta;
                         file.hasEditClick = true;
                         file.parsedData = cleanedEntities;
-                        // file.name = newFileName;
+                        file.name = newFileName;
                         file.originFileObj = newFile;
                         file.originalFileObj = newFile;
-                      });
-                      setTimeout(() => {
-                        //inside a timeout for cypress purposes
-                        window.toastr.success(
-                          `Added Fixed Up File${
-                            allFiles.length > 1 ? "s" : ""
-                          } ${allFiles.map(({ file }) => file.name).join(", ")}`
-                        );
-                      }, 200);
+                      }
                     }
+                  } else {
+                    toKeep.push(file);
                   }
-                } else {
-                  toKeep.push(...cleanedAccepted);
                 }
+                if (filesWIssues.length) {
+                  const { file } = filesWIssues[0];
+                  const allFiles = [...filesWIssues, ...filesWOIssues];
+                  const doAllFilesHaveSameHeaders = allFiles.every(f => {
+                    if (f.userSchema.fields && f.userSchema.fields.length) {
+                      return f.userSchema.fields.every((h, i) => {
+                        return h.path === allFiles[0].userSchema.fields[i].path;
+                      });
+                    }
+                    return false;
+                  });
+                  const multipleFiles = allFiles.length > 1;
+                  const { res } = await showUploadCsvWizardDialog(
+                    "onUploadWizardFinish",
+                    {
+                      dialogProps: {
+                        title: `Fix Up File${multipleFiles ? "s" : ""} ${
+                          multipleFiles ? "" : file.name ? `"${file.name}"` : ""
+                        }`
+                      },
+                      doAllFilesHaveSameHeaders,
+                      filesWIssues: allFiles,
+                      validateAgainstSchema
+                    }
+                  );
 
-                if (toKeep.length === 0) {
-                  window.toastr &&
-                    window.toastr.error(
-                      `It looks like there wasn't any data in your file. Please add some data and try again`
-                    );
+                  if (!res) {
+                    window.toastr.warning(`File Upload Aborted`);
+                    return;
+                  } else {
+                    allFiles.forEach(({ file }, i) => {
+                      const newEntities = res[i];
+                      // const newFileName = removeExt(file.name) + `_updated.csv`;
+                      //swap out file with a new csv file
+                      const { newFile, cleanedEntities } = getNewCsvFile(
+                        newEntities,
+                        file.name
+                      );
+
+                      file.hasEditClick = true;
+                      file.parsedData = cleanedEntities;
+                      // file.name = newFileName;
+                      file.originFileObj = newFile;
+                      file.originalFileObj = newFile;
+                    });
+                    setTimeout(() => {
+                      //inside a timeout for cypress purposes
+                      window.toastr.success(
+                        `Added Fixed Up File${
+                          allFiles.length > 1 ? "s" : ""
+                        } ${allFiles.map(({ file }) => file.name).join(", ")}`
+                      );
+                    }, 200);
+                  }
                 }
-                const cleanedFileList = trimFiles(
-                  [...toKeep, ...fileListToUse],
-                  fileLimit
-                );
-                handleSecondHalfOfUpload({ acceptedFiles, cleanedFileList });
+              } else {
+                toKeep.push(...cleanedAccepted);
               }
+
+              if (toKeep.length === 0) {
+                window.toastr &&
+                  window.toastr.error(
+                    `It looks like there wasn't any data in your file. Please add some data and try again`
+                  );
+              }
+              const cleanedFileList = trimFiles(
+                [...toKeep, ...fileListToUse],
+                fileLimit
+              );
+              handleSecondHalfOfUpload({ acceptedFiles, cleanedFileList });
             }}
             {...dropzoneProps}
           >
@@ -942,71 +990,26 @@ function UploaderInner({
               isDragAccept,
               isDragReject,
               isDragActive
-              // isDragActive
-              // isDragReject
-              // isDragAccept
             }) => (
-              <section>
-                <div
-                  {...getRootProps()}
-                  className={classnames("tg-dropzone", className, {
-                    "tg-dropzone-minimal": minimal,
-                    "tg-dropzone-active": isDragActive,
-                    "tg-dropzone-reject": isDragReject, // tnr: the acceptClassName/rejectClassName doesn't work with file extensions (only mimetypes are supported when dragging). Thus we'll just always turn the drop area blue when dragging and let the filtering occur on drop. See https://github.com/react-dropzone/react-dropzone/issues/888#issuecomment-773938074
-                    "tg-dropzone-accept": isDragAccept,
-                    "tg-dropzone-disabled": dropzoneDisabled,
-                    "bp3-disabled": dropzoneDisabled
-                  })}
-                >
-                  <input {...getInputProps()} />
-                  {contentOverride || (
-                    <div
-                      title={
-                        simpleAccept
-                          ? "Accepts only the following file types: " +
-                            simpleAccept
-                          : "Accepts any file input"
-                      }
-                      className="tg-upload-inner"
-                    >
-                      {innerIcon || (
-                        <Icon icon="upload" iconSize={minimal ? 15 : 30} />
-                      )}
-                      {innerText ||
-                        (minimal ? "Upload" : "Click or drag to upload")}
-                      {validateAgainstSchema && !noBuildCsvOption && (
-                        <div
-                          style={{
-                            textAlign: "center",
-                            // fontSize: 18,
-                            marginTop: 7,
-                            marginBottom: 5
-                          }}
-                          onClick={handleManuallyEnterData}
-                          className="link-button"
-                        >
-                          ...or {manualEnterMessage}
-                          {/* <div
-                            style={{
-                              fontSize: 11,
-                              color: Colors.GRAY3,
-                              fontStyle: "italic"
-                            }}
-                          >
-                            {manualEnterSubMessage}
-                          </div> */}
-                        </div>
-                      )}
-                    </div>
-                  )}
-                </div>
-
-                {showFilesCount ? (
-                  <div className="tg-upload-file-list-counter">
-                    Files: {fileList ? fileList.length : 0}
-                  </div>
-                ) : null}
-              </section>
+              <InnerDropZone
+                getRootProps={getRootProps}
+                getInputProps={getInputProps}
+                isDragAccept={isDragAccept}
+                isDragReject={isDragReject}
+                isDragActive={isDragActive}
+                className={className}
+                minimal={minimal}
+                dropzoneDisabled={dropzoneDisabled}
+                contentOverride={contentOverride}
+                simpleAccept={simpleAccept}
+                innerIcon={innerIcon}
+                innerText={innerText}
+                validateAgainstSchema={validateAgainstSchema}
+                handleManuallyEnterData={handleManuallyEnterData}
+                noBuildCsvOption={noBuildCsvOption}
+                showFilesCount={showFilesCount}
+                fileList={fileList}
+              />
             )}
           </Dropzone>
           {/* {validateAgainstSchema && <CsvWizardHelper bindToggle={{}} validateAgainstSchema={validateAgainstSchema}></CsvWizardHelper>} */}
@@ -1188,12 +1191,9 @@ function UploaderInner({
       </div>
     </>
   );
-}
+};
 
-const Uploader = compose(
-  connect(undefined, { initializeForm: initialize }),
-  observer
-)(UploaderInner);
+const Uploader = observer(UploaderInner);
 
 export default Uploader;
 

--- a/packages/ui/src/FormComponents/tryToMatchSchemas.js
+++ b/packages/ui/src/FormComponents/tryToMatchSchemas.js
@@ -14,12 +14,6 @@ const getSchema = data => ({
     return { path, type: "string" };
   }),
   userData: data
-  // userData: data.map((d) => {
-  //   if (!d.id) {
-  //     d.id = nanoid();
-  //   }
-  //   return d
-  // })
 });
 export default async function tryToMatchSchemas({
   incomingData,

--- a/packages/ui/src/TgSelect/index.js
+++ b/packages/ui/src/TgSelect/index.js
@@ -512,6 +512,7 @@ export const itemListPredicate = (_queryString = "", items, isSimpleSearch) => {
 export function simplesearch(needle, haystack) {
   return (haystack || "").indexOf(needle) !== -1;
 }
+
 function tagOptionRender(vals) {
   if (vals.noTagStyle) return vals.label;
   return <Tag {...getTagProps(vals)}></Tag>;

--- a/packages/ui/src/TgSelect/index.js
+++ b/packages/ui/src/TgSelect/index.js
@@ -512,7 +512,6 @@ export const itemListPredicate = (_queryString = "", items, isSimpleSearch) => {
 export function simplesearch(needle, haystack) {
   return (haystack || "").indexOf(needle) !== -1;
 }
-
 function tagOptionRender(vals) {
   if (vals.noTagStyle) return vals.label;
   return <Tag {...getTagProps(vals)}></Tag>;

--- a/packages/ui/src/index.js
+++ b/packages/ui/src/index.js
@@ -18,11 +18,11 @@ export {
 } from "./DataTable/utils/withSelectedEntities";
 export {
   default as DataTable,
-  ConnectedPagingTool as PagingTool,
-  removeCleanRows
+  ConnectedPagingTool as PagingTool
 } from "./DataTable";
+export { removeCleanRows } from "./DataTable/utils";
 
-export { default as getIdOrCodeOrIndex } from "./DataTable/utils/getIdOrCodeOrIndex";
+export { getIdOrCodeOrIndex } from "./DataTable/utils";
 export { default as convertSchema } from "./DataTable/utils/convertSchema";
 export { default as Loading } from "./Loading";
 export { throwFormError } from "./throwFormError";

--- a/packages/ui/src/showDialogOnDocBody.js
+++ b/packages/ui/src/showDialogOnDocBody.js
@@ -1,4 +1,4 @@
-import ReactDOM from "react-dom";
+import { createRoot } from "react-dom/client";
 import React from "react";
 // import withDialog from "./enhancers/withDialog";
 import { Dialog } from "@blueprintjs/core";
@@ -19,19 +19,15 @@ export default function showDialogOnDocBody(DialogComp, options = {}) {
     DialogCompToUse = props => {
       return (
         <Dialog usePortal={false} title="pass a {title} prop" isOpen {...props}>
-          <DialogComp
-            {...props}
-            hideModal={onClose}
-            onClose={onClose}
-          ></DialogComp>
+          <DialogComp {...props} hideModal={onClose} onClose={onClose} />
         </Dialog>
       );
     };
   } else {
     DialogCompToUse = DialogComp;
   }
-  ReactDOM.render(
-    <DialogCompToUse hideModal={onClose} onClose={onClose} {...options} />,
-    dialogHolder
+  const root = createRoot(dialogHolder);
+  root.render(
+    <DialogCompToUse hideModal={onClose} onClose={onClose} {...options} />
   );
 }

--- a/packages/ui/src/useDialog.js
+++ b/packages/ui/src/useDialog.js
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 
-/* 
+/*
 
   const {toggleDialog, comp} = useDialog({
     ModalComponent: SimpleInsertData,
@@ -31,12 +31,14 @@ export const useDialog = ({ ModalComponent, ...rest }) => {
         ...rest?.dialogProps,
         ...additionalProps?.dialogProps
       }}
-    ></ModalComponent>
+    />
   );
+
   const toggleDialog = () => {
     setOpen(!isOpen);
   };
-  async function showDialogPromise(handlerName, moreProps = {}) {
+
+  const showDialogPromise = async (handlerName, moreProps = {}) => {
     return new Promise(resolve => {
       //return a promise that can be awaited
       setAdditionalProps({
@@ -59,6 +61,7 @@ export const useDialog = ({ ModalComponent, ...rest }) => {
       });
       setOpen(true); //open the dialog
     });
-  }
+  };
+
   return { comp, showDialogPromise, toggleDialog, setAdditionalProps };
 };

--- a/packages/ui/src/utils/renderOnDoc.js
+++ b/packages/ui/src/utils/renderOnDoc.js
@@ -1,29 +1,32 @@
-import ReactDOM from "react-dom";
+import { createRoot } from "react-dom/client";
 
 export function renderOnDoc(fn) {
   const elemDiv = document.createElement("div");
   elemDiv.style.cssText =
     "position:absolute;width:100%;height:100%;top:0px;opacity:0.3;z-index:0;";
   document.body.appendChild(elemDiv);
+  const root = createRoot(elemDiv);
   const handleClose = () => {
     setTimeout(() => {
-      ReactDOM.unmountComponentAtNode(elemDiv);
+      root.unmount(elemDiv);
       document.body.removeChild(elemDiv);
     });
   };
-  return ReactDOM.render(fn(handleClose), elemDiv);
+  root.render(fn(handleClose));
 }
+
 export function renderOnDocSimple(el) {
   const elemDiv = document.createElement("div");
   elemDiv.style.cssText =
     "position:absolute;width:100%;height:100%;top:0px;opacity:1;z-index:10000;";
   document.body.appendChild(elemDiv);
+  const root = createRoot(elemDiv);
+  root.render(el);
   const handleClose = () => {
     setTimeout(() => {
-      ReactDOM.unmountComponentAtNode(elemDiv);
+      root.unmount();
       document.body.removeChild(elemDiv);
     });
   };
-  ReactDOM.render(el, elemDiv);
   return handleClose;
 }


### PR DESCRIPTION
- Divide DataTable into smaller chunks. The file is still too big, but this pr took around 400 lines out.
- Replaced react-dom  render with the new version root and replaced react-dom utilities with useRef and createRef.
- Took mobx out of uploader component.
- refactor UploadCsvWizard so it uses hooks instead of connect  

@tnrich
