### PR TITLE
Add doubleClickOverrides prop to the Editor component to address #96

### DIFF
--- a/packages/ove/src/Editor/index.js
+++ b/packages/ove/src/Editor/index.js
@@ -381,7 +381,8 @@ export class Editor extends React.Component {
       withRotateCircularView = true,
       withZoomCircularView = true,
       withZoomLinearView = true,
-      withPreviewMode
+      withPreviewMode,
+      doubleClickOverrides
     } = this.props;
     if (
       !this.props.noVersionHistory &&
@@ -589,6 +590,7 @@ export class Editor extends React.Component {
           fontHeightMultiplier={this.props.fontHeightMultiplier}
           rightClickOverrides={this.props.rightClickOverrides}
           clickOverrides={this.props.clickOverrides}
+          doubleClickOverrides={doubleClickOverrides}
           {...panelPropsToSpread}
           editorName={editorName}
           isProtein={sequenceData.isProtein}

--- a/packages/ove/src/withEditorInteractions/clickAndDragUtils.js
+++ b/packages/ove/src/withEditorInteractions/clickAndDragUtils.js
@@ -574,3 +574,14 @@ function getMinRangeLength(start, end, sequenceLength, doNotWrapOrigin) {
   }
   return range1 < range2 ? range1 : range2;
 }
+
+export function handleDoubleClick({
+  event,
+  annotation,
+  doubleClickOverrides = {}
+}) {
+  const handler = doubleClickOverrides[annotation.type + "DoubleClicked"];
+  if (handler) {
+    handler({ event, annotation });
+  }
+}

--- a/packages/ove/src/withEditorInteractions/index.js
+++ b/packages/ove/src/withEditorInteractions/index.js
@@ -33,7 +33,8 @@ import Keyboard from "./Keyboard";
 import {
   handleCaretMoved,
   editorClicked,
-  updateSelectionOrCaret
+  updateSelectionOrCaret,
+  handleDoubleClick
 } from "./clickAndDragUtils";
 import getBpsPerRow from "./getBpsPerRow";
 import {
@@ -77,7 +78,7 @@ function VectorInteractionHOC(Component /* options */) {
       super(props);
       annotationClickHandlers.forEach(handler => {
         this[handler] = (...args) => {
-          const { clickOverrides = {} } = this.props;
+          const { clickOverrides = {}, doubleClickOverrides = {} } = this.props;
           let preventDefault;
           const defaultHandler = this[handler + "_localOverride"]
             ? this[handler + "_localOverride"]
@@ -1173,6 +1174,12 @@ function VectorInteractionHOC(Component /* options */) {
             editorClicked({
               ...p,
               updateSelectionOrCaret: this.updateSelectionOrCaret
+            });
+          },
+          handleDoubleClick: p => {
+            handleDoubleClick({
+              ...p,
+              doubleClickOverrides: this.props.doubleClickOverrides
             });
           }
         };


### PR DESCRIPTION
This PR was done with the GitHub Copilot Workspaces Technical Preview. (I'm friends with @tnrich and he wanted to see it in action)

Add a `doubleClickOverrides` prop to the `Editor` component to handle double-click events.

* **Editor Component:**
  - Add `doubleClickOverrides` prop to the `Editor` component in `packages/ove/src/Editor/index.js`.
  - Pass `doubleClickOverrides` prop to child components in `packages/ove/src/Editor/index.js`.

* **withEditorInteractions HOC:**
  - Add `doubleClickOverrides` prop to the `VectorInteractionWrapper` component in `packages/ove/src/withEditorInteractions/index.js`.
  - Handle double-click events in the `VectorInteractionWrapper` component in `packages/ove/src/withEditorInteractions/index.js`.
  - Pass `doubleClickOverrides` prop to child components in `packages/ove/src/withEditorInteractions/index.js`.

* **clickAndDragUtils:**
  - Add `handleDoubleClick` function to handle double-click events in `packages/ove/src/withEditorInteractions/clickAndDragUtils.js`.
  - Export `handleDoubleClick` function in `packages/ove/src/withEditorInteractions/clickAndDragUtils.js`.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/TeselaGen/tg-oss?shareId=b2a08a87-e194-4d63-9888-e39df5241fc5).