### PR TITLE
Expose files in package to workaround multiple version of react

### DIFF
--- a/packages/ove/package.json
+++ b/packages/ove/package.json
@@ -8,6 +8,7 @@
       "import": "./index.es.js",
       "require": "./index.cjs.js"
     },
-    "./style.css": "./style.css"
+    "./style.css": "./style.css",
+    "./*": "./*"
   }
 }

--- a/packages/ove/package.json
+++ b/packages/ove/package.json
@@ -8,7 +8,6 @@
       "import": "./index.es.js",
       "require": "./index.cjs.js"
     },
-    "./style.css": "./style.css",
     "./*": "./*"
   }
 }


### PR DESCRIPTION
<!-- please include this @tnrich tag so I get an email :) -->

@tnrich

Since the package pinned react 18 and we use react 19 now.

We don't want to import the package and get multiple instances of react imported when importing the cjs/es file.
We would like to relax the export field a little bit so we can import a specific source file in the package https://www.npmjs.com/package/@teselagen/ove?activeTab=code without introducing another version of react.