### PR TITLE
change the display position for primer direction number

### DIFF
--- a/packages/ove/src/RowItem/Sequence.js
+++ b/packages/ove/src/RowItem/Sequence.js
@@ -154,6 +154,9 @@ class Sequence extends React.Component {
             className={`tg-${
               isReverse ? "left" : "right"
             }-prime-direction tg-prime-direction`}
+            style={
+              !isReverse ? { left: startOffset * charWidth + width } : undefined
+            }
           >
             3'
           </div>
@@ -163,6 +166,9 @@ class Sequence extends React.Component {
             className={`tg-${
               isReverse ? "right" : "left"
             }-prime-direction tg-prime-direction`}
+            style={
+              isReverse ? { left: startOffset * charWidth + width } : undefined
+            }
           >
             5'
           </div>


### PR DESCRIPTION
<!-- please include this @tnrich tag so I get an email :) -->

@tnrich


maybe it's better to show the direction `5'` or `3'` just near the sequence

before:
<img width="1587" alt="Screenshot 2025-02-13 at 10 03 23" src="https://github.com/user-attachments/assets/759dc5e0-c385-457f-bf05-9e63d23bd67a" />


after:
<img width="1587" alt="Screenshot 2025-02-13 at 10 03 04" src="https://github.com/user-attachments/assets/895103a8-8980-42de-984a-13c7938f96ea" />

