### PR TITLE
Support ploc1 field

### DIFF
--- a/packages/bio-parsers/src/ab1ToJson.js
+++ b/packages/bio-parsers/src/ab1ToJson.js
@@ -80,6 +80,9 @@ function abConverter(inputArrayBuffer) {
     traceData.gTrace = this.getDataTag(tagDict.colorDataG);
     traceData.cTrace = this.getDataTag(tagDict.colorDataC);
     traceData.basePos = this.getDataTag(tagDict.peakLocations);
+    if (traceData.basePos === undefined) {
+      traceData.basePos = this.getDataTag(tagDict.peakLocationsUser);
+    }
     traceData.baseCalls = this.getDataTag(tagDict.baseCalls2);
     traceData.qualNums = this.getDataTag(tagDict.qualNums);
     if (traceData.qualNums) {
@@ -109,6 +112,7 @@ const tagDict = {
   baseCalls2: { tagName: "PBAS", tagNum: 2, typeToReturn: "getChar" },
   qualNums: { tagName: "PCON", tagNum: 2, typeToReturn: "getNumber" },
   peakLocations: { tagName: "PLOC", tagNum: 2, typeToReturn: "getShort" },
+  peakLocationsUser: { tagName: "PLOC", tagNum: 1, typeToReturn: "getShort" },
   peakDev: { tagName: "P1RL", tagNum: 1, typeToReturn: "getShort" },
   peakOneAmp: { tagName: "P1AM", tagNum: 1, typeToReturn: "getShort" },
   colorDataA: { tagName: "DATA", tagNum: 10, typeToReturn: "getShort" },


### PR DESCRIPTION
Hello @tnrich I could not open some ab1 files from a collaborator. He received them from Plasmidsaurus, a known whole-plasmid sequencing company.

The reason for this seems to be that they store the information of PLOC in PLOC1 instead of PLOC2. I guess this is because the peaks don't really come from a Sanger sequencing machine (they do nanopore), and therefore they put them in the "manual" field. Below Biopython docs on the meaning of this field.

```
    "PLOC1": "Array of peak locations edited by user",
    "PLOC2": "Array of peak locations as called by Basecaller",
```

In the current PR I try to get PLOC2 as before and otherwise get PLOC1 instead. Let me know if you think this makes sense.

Unfortunately, I cannot share the data from this person since it is unpublished, but tagging @mmcguffi in case he can provide a minimal example for a test. If you think this change does not break things on your side, I would appreciate it if you can release it.

