### PR TITLE
getStructuredBases - handle origin-spanning primers

### DIFF
--- a/packages/ove/cypress/e2e/getStructuredBases.js
+++ b/packages/ove/cypress/e2e/getStructuredBases.js
@@ -1,0 +1,211 @@
+import { getStructuredBases } from "../../src/RowItem/StackedAnnotations/getStructuredBases";
+
+describe("getStructuredBases", () => {
+  it("works for fully-overlapping non origin-spanning case", () => {
+    const fullSequence = "ACGTCCACGT";
+    let primerSeq = "ACGT";
+    const start = 0;
+    const end = 3;
+    let { allBasesWithMetaData } = getStructuredBases({
+      annotationRange: { start, end },
+      forward: true,
+      bases: primerSeq,
+      start: start,
+      end: end,
+      fullSequence,
+      primerBindsOn: "3prime",
+      sequenceLength: fullSequence.length
+    });
+
+    let expected = [true, true, true, true];
+    assert.deepEqual(
+      allBasesWithMetaData.map(({ isMatch }) => isMatch),
+      expected
+    );
+
+    primerSeq = "CCGT";
+    ({ allBasesWithMetaData } = getStructuredBases({
+      annotationRange: { start, end },
+      forward: true,
+      bases: primerSeq,
+      start: start,
+      end: end,
+      fullSequence,
+      primerBindsOn: "3prime",
+      sequenceLength: fullSequence.length
+    }));
+    expected = [false, true, true, true];
+    assert.deepEqual(
+      allBasesWithMetaData.map(({ isMatch }) => isMatch),
+      expected
+    );
+  });
+  it("works for non fully-overlapping non origin-spanning case binding on 3prime", () => {
+    const fullSequence = "ACGTCCACGT";
+    let primerSeq = "aaaaACGT";
+    const start = 0;
+    const end = 3;
+    let { allBasesWithMetaData } = getStructuredBases({
+      annotationRange: { start, end },
+      forward: true,
+      bases: primerSeq,
+      start: start,
+      end: end,
+      fullSequence,
+      primerBindsOn: "3prime",
+      sequenceLength: fullSequence.length
+    });
+
+    let expected = [false, false, false, false, true, true, true, true];
+    assert.deepEqual(
+      allBasesWithMetaData.map(({ isMatch }) => isMatch),
+      expected
+    );
+    expected = [
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      false,
+      false,
+      false,
+      false
+    ];
+    assert.deepEqual(
+      allBasesWithMetaData.map(({ isAmbiguousMatch }) => isAmbiguousMatch),
+      expected
+    );
+
+    primerSeq = "aaaaCCGT";
+    ({ allBasesWithMetaData } = getStructuredBases({
+      annotationRange: { start, end },
+      forward: true,
+      bases: primerSeq,
+      start: start,
+      end: end,
+      fullSequence,
+      primerBindsOn: "3prime",
+      sequenceLength: fullSequence.length
+    }));
+    expected = [false, false, false, false, false, true, true, true];
+    assert.deepEqual(
+      allBasesWithMetaData.map(({ isMatch }) => isMatch),
+      expected
+    );
+    expected = [
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      false,
+      false,
+      false,
+      false
+    ];
+    assert.deepEqual(
+      allBasesWithMetaData.map(({ isAmbiguousMatch }) => isAmbiguousMatch),
+      expected
+    );
+  });
+  it("works for non fully-overlapping non origin-spanning case binding on 5prime", () => {
+    const fullSequence = "ACGTCCACGT";
+    let primerSeq = "ACGTaaaa";
+    const start = 0;
+    const end = 3;
+    let { allBasesWithMetaData } = getStructuredBases({
+      annotationRange: { start, end },
+      forward: true,
+      bases: primerSeq,
+      start: start,
+      end: end,
+      fullSequence,
+      primerBindsOn: "5prime",
+      sequenceLength: fullSequence.length
+    });
+
+    assert.deepEqual(
+      allBasesWithMetaData.map(({ isMatch }) => isMatch),
+      [true, true, true, true, false, false, false, false]
+    );
+    assert.deepEqual(
+      allBasesWithMetaData.map(({ isAmbiguousMatch }) => isAmbiguousMatch),
+      [false, false, false, false, undefined, undefined, undefined, undefined]
+    );
+
+    primerSeq = "CCGTaaaa";
+    ({ allBasesWithMetaData } = getStructuredBases({
+      annotationRange: { start, end },
+      forward: true,
+      bases: primerSeq,
+      start: start,
+      end: end,
+      fullSequence,
+      primerBindsOn: "5prime",
+      sequenceLength: fullSequence.length
+    }));
+    assert.deepEqual(
+      allBasesWithMetaData.map(({ isMatch }) => isMatch),
+      [false, true, true, true, false, false, false, false]
+    );
+    assert.deepEqual(
+      allBasesWithMetaData.map(({ isAmbiguousMatch }) => isAmbiguousMatch),
+      [false, false, false, false, undefined, undefined, undefined, undefined]
+    );
+  });
+  it("works for origin-spanning case", () => {
+    const fullSequence = "ACGTCCACGT";
+    let primerSeq = "TACGT";
+    const start = 9;
+    const end = 3;
+    // First part of the primer binding to the origin
+    let { allBasesWithMetaData } = getStructuredBases({
+      annotationRange: { start: 9, end: 9 },
+      forward: true,
+      bases: primerSeq,
+      start: start,
+      end: end,
+      fullSequence,
+      primerBindsOn: "3prime",
+      sequenceLength: fullSequence.length
+    });
+    let expected = [true];
+    assert.deepEqual(
+      allBasesWithMetaData.map(({ isMatch }) => isMatch),
+      expected
+    );
+    // Second part of the primer binding to the origin
+    ({ allBasesWithMetaData } = getStructuredBases({
+      annotationRange: { start: 0, end: 3 },
+      forward: true,
+      bases: primerSeq,
+      start: start,
+      end: end,
+      fullSequence,
+      primerBindsOn: "3prime",
+      sequenceLength: fullSequence.length
+    }));
+    expected = [true, true, true, true];
+    assert.deepEqual(
+      allBasesWithMetaData.map(({ isMatch }) => isMatch),
+      expected
+    );
+
+    // Mismatch
+    primerSeq = "AACGT";
+    expected = [false];
+    ({ allBasesWithMetaData } = getStructuredBases({
+      annotationRange: { start: 9, end: 9 },
+      forward: true,
+      bases: primerSeq,
+      start: start,
+      end: end,
+      fullSequence,
+      primerBindsOn: "3prime",
+      sequenceLength: fullSequence.length
+    }));
+    assert.deepEqual(
+      allBasesWithMetaData.map(({ isMatch }) => isMatch),
+      expected
+    );
+  });
+});

--- a/packages/ove/demo/src/exampleData/exampleSequenceData.js
+++ b/packages/ove/demo/src/exampleData/exampleSequenceData.js
@@ -34,6 +34,26 @@ export default {
       end: 300,
       type: "primer_bind",
       forward: true
+    },
+    {
+      name: "Origin-spanning primer",
+      start: 5297,
+      end: 4,
+      type: "primer_bind",
+      forward: true,
+      color: "red",
+      primerBindsOn: "3prime",
+      bases: "tcgacgt"
+    },
+    {
+      name: "Origin-spanning reverse primer",
+      start: 5297,
+      end: 4,
+      type: "primer_bind",
+      forward: false,
+      color: "red",
+      primerBindsOn: "3prime",
+      bases: "acgtcga"
     }
   ],
   afeatures: [

--- a/packages/ove/src/RowItem/StackedAnnotations/getStructuredBases.js
+++ b/packages/ove/src/RowItem/StackedAnnotations/getStructuredBases.js
@@ -28,11 +28,25 @@ export function getStructuredBases({
       }
     }
   }
-  const aRange = {
-    //tnr: this probably needs to be changed in case annotation wraps origin
-    start: annotationRange.start - start,
-    end: annotationRange.end - start
-  };
+
+  const wrapsOrigin = start > end;
+  let aRange;
+  if (!wrapsOrigin) {
+    aRange = {
+      //tnr: this probably needs to be changed in case annotation wraps origin
+      start: annotationRange.start - start,
+      end: annotationRange.end - start
+    };
+  } else {
+    aRange = {
+      start: annotationRange.start === 0 ? sequenceLength - start : 0,
+      end:
+        annotationRange.start === 0
+          ? annLen - 1
+          : getRangeLength(annotationRange) - 1
+    };
+  }
+
   const r = {
     aRange,
     basesNoInserts: basesToUse,
@@ -63,7 +77,7 @@ export function getStructuredBases({
     forward ? r.basesNoInserts : r.basesNoInserts.split("").reverse().join("")
   );
   r.basesNoInsertsWithMetaData = basesForRange.split("").map((b, i) => {
-    const indexOfBase = i + annotationRange.start;
+    const indexOfBase = (i + annotationRange.start) % sequenceLength;
     let seqForBase = (fullSequence && fullSequence[indexOfBase]) || "";
     if (!forward) {
       seqForBase = getComplementSequenceString(seqForBase);


### PR DESCRIPTION
Closes #91, followup to #92

Hi @tnrich, I implemented a fix for this. I have written a unit test for `getStructuredBases` and included it in the cypress/e2e folder. I saw that there were some spec.js files in the `test` directory of `ove` but I am not sure how to run those specs (are they even ran by the CI/CD?). I could not find them in cypress
