### PR TITLE
keep stop codons in fasta file

### DIFF
--- a/packages/bio-parsers/src/fastaToJson.js
+++ b/packages/bio-parsers/src/fastaToJson.js
@@ -62,14 +62,7 @@ function fastaToJson(fileString, options = {}) {
       if (!result) {
         result = createInitialSequence(options);
       }
-      if ("*" === line[line.length - 1]) {
-        //some resultArray are ended with an asterisk
-        parseSequenceLine(line.substring(0, line.length - 1));
-        resultArray.push(result);
-        result = null;
-      } else {
-        parseSequenceLine(line);
-      }
+      parseSequenceLine(line);
     }
     if (options && options.parseFastaAsCircular) {
       result.parsedSequence.circular = true;

--- a/packages/bio-parsers/test/fastaToJson.test.js
+++ b/packages/bio-parsers/test/fastaToJson.test.js
@@ -22,11 +22,24 @@ describe("FASTA tests", function () {
     result[0].parsedSequence.description.should.equal(
       "359950697|gb|AEV91138.1| Rfp (plasmid) [synthetic construct]"
     );
+    console.log(result[0].parsedSequence.sequence);
     result[0].parsedSequence.sequence.should.equal(
       "MRSSKNVIKEFMRFKVRMEGTVNGHEFEIEGEGEGRPYEGHNTVKLKVTKGGPLPFAWDILSPQFQYGSKVYVKHPADIPDYKKLSFPEGFKWERVMNFEDGGVVTVTQDSSLQDGCFIYKVKFIGVNFPSDGPVMQKKTMGWEASTERLYPRDGVLKGEIHKALKLKDGGHYLVEFKSIYMAKKPVQLPGYYYVDSKLDITSHNEDYTIVEQYERTEGRHHLFL"
     );
     result[0].parsedSequence.isProtein.should.equal(true);
   });
+
+  it("Protein Fasta with stop codons (*) at the end should be kept", async function () {
+    const string = fs.readFileSync(
+      path.join(__dirname, "./testData/fasta/fasta_with_stop_codons.fasta"),
+      "utf8"
+    );
+    const result = await fastaToJson(string, { fileName: "fasta_with_stop_codons.faa" });
+    result[0].parsedSequence.sequence.should.equal(
+      "AGCTTT*TAAAA*"
+    );
+  });
+
   it("import protein fasta file without replacing spaces to underscore in name", async function () {
     const string = fs.readFileSync(
       path.join(__dirname, "./testData/fasta/proteinFasta.fas"),

--- a/packages/bio-parsers/test/genbankToJson.test.js
+++ b/packages/bio-parsers/test/genbankToJson.test.js
@@ -1117,6 +1117,17 @@ ORIGIN
       "end should be 0"
     );
   });
+
+  it("Protein Fasta with stop codons (*) at the end should be kept", async function () {
+    const string = fs.readFileSync(
+      path.join(__dirname, "./testData/genbank/protein_with_stop_codons.gp"),
+      "utf8"
+    );
+    const result = genbankToJson(string);
+    result[0].parsedSequence.sequence.should.equal(
+      "aaaggggy*yyy*"
+    );
+  });
 });
 
 // const string = fs.readFileSync(path.join(__dirname, '../../../..', './testData/genbank (JBEI Private)/46.gb'), "utf8");

--- a/packages/bio-parsers/test/testData/fasta/fasta_with_stop_codons.fasta
+++ b/packages/bio-parsers/test/testData/fasta/fasta_with_stop_codons.fasta
@@ -1,0 +1,2 @@
+>ssrA_tag_enhance
+AGCTTT*TAAAA*

--- a/packages/bio-parsers/test/testData/genbank/protein_with_stop_codons.gp
+++ b/packages/bio-parsers/test/testData/genbank/protein_with_stop_codons.gp
@@ -1,0 +1,19 @@
+LOCUS       Untitled_8          13 aa            linear   UNA 28-APR-2025
+DEFINITION  natural linear DNA
+ACCESSION   .
+VERSION     .
+DBSOURCE    .
+KEYWORDS    .
+SOURCE      natural protein sequence
+  ORGANISM  unspecified
+REFERENCE   1  (residues 1 to 13)
+  AUTHORS   SnapGene License
+  TITLE     Direct Submission
+  JOURNAL   Exported Apr 28, 2025 from SnapGene 7.0.1
+            https://www.snapgene.com
+FEATURES             Location/Qualifiers
+     source          1..13
+                     /organism="unspecified"
+ORIGIN
+        1 aaaggggy*y yy*
+//


### PR DESCRIPTION
<!-- please include this @tnrich tag so I get an email :) -->

@tnrich

The stop code is supported in genbank file for protein sequences, to keep consistent, we may also need to keep the stop code (`*`) of protein sequence in fasta file.