### PR TITLE
fix overflow label in 'Circular Map' and 'Sequence Map'

### DIFF
--- a/packages/ove/cypress/e2e/labels.js
+++ b/packages/ove/cypress/e2e/labels.js
@@ -26,7 +26,7 @@ describe("label tests", () => {
     cy.get(".tg-test-start input").clear().type("100");
     cy.get(".tg-test-end input").clear().type("120");
     cy.get(".tg-upsert-annotation").contains("Save").click();
-    cy.get(`.veLabelText:contains(测试 テスト 테스트한국어)`).first().trigger("mouseover");
+    cy.get(`.veLabelText:contains(测试 テスト 테스트한국어)`).first().trigger("mouseover", {force: true});
     cy.get(`.veLabelText.veAnnotationHovered:contains('测试 テスト 테스트한국어 тестированиерусский!@#￥%&*()_+{❤|:abcdefghijkl..')`);
     cy.get(`.veRowItemWrapper .veLabelText:contains('测试 テスト 테스트한국어 тестированиерусский!@#￥%&*()_+{❤|:abcdefghij..')`);
   })

--- a/packages/ove/cypress/e2e/labels.js
+++ b/packages/ove/cypress/e2e/labels.js
@@ -16,6 +16,20 @@ describe("label tests", () => {
     cy.contains(".veLabelText", "GFPuv");
     cy.contains("veLabelText", "pS8c-vector..").should("not.exist");
   });
+  it (`getTextLengthWithCollapseSpace function should work correctly`, () => {
+    cy.visit("#/Editor?showCicularViewInternalLabels=false");
+    cy.get(".tg-menu-bar").contains("Edit").click();
+
+    cy.contains(".bp3-menu-item", "Create").click();
+    cy.contains(".bp3-menu-item", "New Part").click({ force: true });
+    cy.get(".tg-test-name input").clear().type("测试 テスト 테스트한국어 тестированиерусский!@#￥%&*()_+{❤|:abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ");
+    cy.get(".tg-test-start input").clear().type("100");
+    cy.get(".tg-test-end input").clear().type("120");
+    cy.get(".tg-upsert-annotation").contains("Save").click();
+    cy.get(`.veLabelText:contains(测试 テスト 테스트한국어)`).first().trigger("mouseover");
+    cy.get(`.veLabelText.veAnnotationHovered:contains('测试 テスト 테스트한국어 тестированиерусский!@#￥%&*()_+{❤|:abcdefghijkl..')`);
+    cy.get(`.veRowItemWrapper .veLabelText:contains('测试 テスト 테스트한국어 тестированиерусский!@#￥%&*()_+{❤|:abcdefghij..')`);
+  })
   it(`should show/hide a checkmark when toggling feature label visibility`, function () {
     cy.visit("#/Editor?showCicularViewInternalLabels=false");
     cy.contains(".veCircularViewLabelText", "araC");

--- a/packages/ove/src/CircularView/Labels/index.js
+++ b/packages/ove/src/CircularView/Labels/index.js
@@ -271,7 +271,7 @@ const DrawLabelGroup = withHover(function ({
     const maxLabelWidth = maxLabelLength * fontWidth;
 
     labelXStart = label.x - (labelOnLeft ? maxLabelWidth : 0);
-    let distancePastBoundary =  Math.abs(label.x + (labelOnLeft ? -maxLabelLength : maxLabelLength)) - maxDistance;
+    let distancePastBoundary =  Math.abs(label.x + (labelOnLeft ? -maxLabelWidth : maxLabelWidth)) - maxDistance;
     let lableRectWidth = maxLabelWidth - 14;
 
     if (maxLabelWidth > maxDistance * 2) {

--- a/packages/ove/src/CircularView/Labels/index.js
+++ b/packages/ove/src/CircularView/Labels/index.js
@@ -8,20 +8,6 @@ import { avoidOverlapWith } from "../drawAnnotations";
 
 const fontWidthToFontSize = 1.75;
 
-const singleEnStringWidthMap = {};
-export const getSingleEnStringWidth = fontSize => {
-  if (singleEnStringWidthMap[fontSize]) {
-    return singleEnStringWidthMap[fontSize];
-  }
-
-  const canvas = document.createElement("canvas");
-  const context = canvas.getContext("2d");
-  context.font = `${fontSize}px Menlo, Monaco, monospace`;
-  const singleEnStringWidth = context.measureText("A").width;
-  singleEnStringWidthMap[fontSize] = singleEnStringWidth;
-  return singleEnStringWidth;
-};
-
 export const getTextLength = text => {
   const displayTextForWrappedWhitespace = (text || "Unlabeled").replaceAll(
     /\s+/g,

--- a/packages/ove/src/CircularView/Labels/index.js
+++ b/packages/ove/src/CircularView/Labels/index.js
@@ -8,16 +8,19 @@ import { avoidOverlapWith } from "../drawAnnotations";
 
 const fontWidthToFontSize = 1.75;
 
-export const getTextLength = text => {
-  const displayTextForWrappedWhitespace = (text || "Unlabeled").replaceAll(
-    /\s+/g,
-    " "
-  );
-  let len = displayTextForWrappedWhitespace.length;
+export const getTextLengthWithCollapseSpace = (text, collapseWhiteSpace = true) => {
+  let displayText = text || "Unlabeled";
+  if (collapseWhiteSpace) {
+    displayText = displayText.replaceAll(
+      /\s+/g,
+      " "
+    );
+  }
+  let len = displayText.length;
   // eslint-disable-next-line no-control-regex
   const nonEnInputReg = /[^\x00-\xff]+/g;
   const nonEnStrings =
-    displayTextForWrappedWhitespace.match(nonEnInputReg) || [];
+  displayText.match(nonEnInputReg) || [];
   nonEnStrings.forEach(str => (len += str.length * 0.5));
   return len;
 };
@@ -63,7 +66,7 @@ function Labels({
         _annotationCenterAngle + (rotationRadians || 0);
       return {
         ...label,
-        width: getTextLength(label.text) * fontWidth,
+        width: getTextLengthWithCollapseSpace(label.text) * fontWidth,
         //three points define the label:
         innerPoint: {
           ...polarToSpecialCartesian(
@@ -229,7 +232,7 @@ const DrawLabelGroup = withHover(function ({
     // }
   }
 
-  const textLength = getTextLength(text);
+  const textLength = getTextLengthWithCollapseSpace(text);
   const labelLength = textLength * fontWidth;
 
   // Calculate the maximum label length for hovered status
@@ -237,7 +240,7 @@ const DrawLabelGroup = withHover(function ({
     currentLength,
     { text = "Unlabeled" }
   ) {
-    const _textLength = getTextLength(text);
+    const _textLength = getTextLengthWithCollapseSpace(text);
     if (_textLength > currentLength) {
       return _textLength;
     }
@@ -289,7 +292,7 @@ const DrawLabelGroup = withHover(function ({
       labelXStart += overflowDistance;
       maxLabelWidth -= overflowDistance;
       truncatedLabelAndSublabels = labelAndSublabels.map(lable => {
-        const labelWidth = getTextLength(lable.text) * fontWidth;
+        const labelWidth = getTextLengthWithCollapseSpace(lable.text) * fontWidth;
         const truncatedText =
           labelWidth >= maxLabelWidth
             ? lable.text.slice(
@@ -398,7 +401,7 @@ const DrawLabelGroup = withHover(function ({
         data-title={label.title || label.text}
         {...avoidOverlapWith}
         x={labelXStart}
-        textLength={getTextLength(text) * fontWidth}
+        textLength={getTextLengthWithCollapseSpace(text) * fontWidth}
         lengthAdjust="spacing"
         className={
           labelClass + label.className + (hovered ? " veAnnotationHovered" : "")
@@ -472,7 +475,7 @@ const DrawGroupInnerLabel = withHover(
         data-title={label.title}
         {...avoidOverlapWith}
         x={labelXStart}
-        textLength={getTextLength(label.text) * fontWidth}
+        textLength={getTextLengthWithCollapseSpace(label.text) * fontWidth}
         lengthAdjust="spacing"
         onClick={label.onClick}
         onDoubleClick={e => {

--- a/packages/ove/src/RowItem/Labels.js
+++ b/packages/ove/src/RowItem/Labels.js
@@ -8,6 +8,7 @@ import { reduce, values, startCase, filter, clamp } from "lodash-es";
 import { getRangeLength } from "@teselagen/range-utils";
 import { doesLabelFitInAnnotation } from "./utils";
 import getAnnotationNameAndStartStopString from "../utils/getAnnotationNameAndStartStopString";
+import { getTextLength } from "../CircularView/Labels";
 
 const BUFFER_WIDTH = 6; //labels shouldn't be less than 6px from eachother on the same line
 
@@ -98,11 +99,11 @@ function Labels(props) {
       annotation = annotationRange;
     }
     const annotationLength =
-      (
+      getTextLength(
         annotation.name ||
-        (annotation.restrictionEnzyme && annotation.restrictionEnzyme.name) ||
-        ""
-      ).length * textWidth;
+          (annotation.restrictionEnzyme && annotation.restrictionEnzyme.name) ||
+          ""
+      ) * textWidth;
     let { xStart, width } = getXStartAndWidthOfRowAnnotation(
       annotationRange,
       bpsPerRow,

--- a/packages/ove/src/RowItem/Labels.js
+++ b/packages/ove/src/RowItem/Labels.js
@@ -8,7 +8,7 @@ import { reduce, values, startCase, filter, clamp } from "lodash-es";
 import { getRangeLength } from "@teselagen/range-utils";
 import { doesLabelFitInAnnotation } from "./utils";
 import getAnnotationNameAndStartStopString from "../utils/getAnnotationNameAndStartStopString";
-import { getTextLength } from "../CircularView/Labels";
+import { getTextLengthWithCollapseSpace } from "../CircularView/Labels";
 
 const BUFFER_WIDTH = 6; //labels shouldn't be less than 6px from eachother on the same line
 
@@ -99,7 +99,7 @@ function Labels(props) {
       annotation = annotationRange;
     }
     const annotationLength =
-      getTextLength(
+    getTextLengthWithCollapseSpace(
         annotation.name ||
           (annotation.restrictionEnzyme && annotation.restrictionEnzyme.name) ||
           ""

--- a/packages/ove/src/helperComponents/withHover.js
+++ b/packages/ove/src/helperComponents/withHover.js
@@ -103,11 +103,11 @@ export default compose(
           hoveredAnnotationUpdate(idToPass, { editorName });
       },
     onMouseLeave: props => e => {
-      // hoveredAnnEasyStore.hoveredAnn = undefined;
-      // const { editorName, hoveredAnnotationClear } = props;
-      // e.stopPropagation();
-      // if (window.__veDragging || window.__veScrolling) return;
-      // hoveredAnnotationClear && hoveredAnnotationClear(true, { editorName });
+      hoveredAnnEasyStore.hoveredAnn = undefined;
+      const { editorName, hoveredAnnotationClear } = props;
+      e.stopPropagation();
+      if (window.__veDragging || window.__veScrolling) return;
+      hoveredAnnotationClear && hoveredAnnotationClear(true, { editorName });
     }
   })
 );

--- a/packages/ove/src/helperComponents/withHover.js
+++ b/packages/ove/src/helperComponents/withHover.js
@@ -103,11 +103,11 @@ export default compose(
           hoveredAnnotationUpdate(idToPass, { editorName });
       },
     onMouseLeave: props => e => {
-      hoveredAnnEasyStore.hoveredAnn = undefined;
-      const { editorName, hoveredAnnotationClear } = props;
-      e.stopPropagation();
-      if (window.__veDragging || window.__veScrolling) return;
-      hoveredAnnotationClear && hoveredAnnotationClear(true, { editorName });
+      // hoveredAnnEasyStore.hoveredAnn = undefined;
+      // const { editorName, hoveredAnnotationClear } = props;
+      // e.stopPropagation();
+      // if (window.__veDragging || window.__veScrolling) return;
+      // hoveredAnnotationClear && hoveredAnnotationClear(true, { editorName });
     }
   })
 );


### PR DESCRIPTION
<!-- please include this @tnrich tag so I get an email :) -->

UI for multiple spaces in names before fix:
when hover on the name with multiple spaces, the space between characters are too large
![white_space_bug](https://github.com/user-attachments/assets/8e1c91f9-9b51-407f-8673-264065449533)

after fix:
![white_space](https://github.com/user-attachments/assets/74e4fb26-74c5-4b31-a9a1-e289f3a28a66)

UI for long name with non english characters before fix:
when hover on the long name, the tooltip will overflow the whose page.
![long_name_with_non_eng_bug](https://github.com/user-attachments/assets/8db95765-80d0-42f9-ad06-c3983d487114)

after fix:
![long_name_with_no_eng_char](https://github.com/user-attachments/assets/f985394f-8830-4bf2-88ad-9e0fc873c5cc)


@tnrich
