### PR TITLE
add Pyrrolysine support

### DIFF
--- a/packages/sequence-utils/src/proteinAlphabet.js
+++ b/packages/sequence-utils/src/proteinAlphabet.js
@@ -112,6 +112,15 @@ const proteinAlphabet = {
     mass: 128.17228
   },
 
+  O: {
+    value: "O",
+    name: "Pyrrolysine",
+    threeLettersName: "Pyl",
+    colorByFamily: "#FFC0CB",
+    color: "hsl(264.7, 100%, 69%)",
+    mass: 255.313
+  },
+
   M: {
     value: "M",
     name: "Methionine",


### PR DESCRIPTION
<!-- please include this @tnrich tag so I get an email :) -->

support show `O`:
<img width="752" height="443" alt="Screenshot 2025-08-07 at 17 03 23" src="https://github.com/user-attachments/assets/4ce23e62-ad75-4927-9c77-35fad86b6894" />

But I can not find the `hydrophobicity` for `Pyrrolysine`, and the `mass` value may need change to keep the precision consistent with other amino acid


@tnrich