### PR TITLE
fix indicator message for protein caret

### DIFF
--- a/packages/ove/cypress/e2e/proteinEditor.js
+++ b/packages/ove/cypress/e2e/proteinEditor.js
@@ -152,6 +152,8 @@ describe("proteinEditor", function () {
     cy.get(".veStatusBarItem")
       .contains("Selecting 11 AAs from 10 to 20")
       .should("be.visible");
+    cy.get('[title="Caret Between AAs 9 and 10"]').should('exist');
+    cy.get('[title="Caret Between AAs 20 and 21"]').should('exist');
   });
 
   it(`goTo, rotateTo work

--- a/packages/ove/src/CircularView/SelectionLayer.js
+++ b/packages/ove/src/CircularView/SelectionLayer.js
@@ -103,6 +103,7 @@ function SelectionLayer({
           onClick={onClick ? noop : preventDefaultStopPropagation}
           selectionMessage={selectionMessage}
           caretPosition={start}
+          isProtein={isProtein}
           sequenceLength={sequenceLength}
           innerRadius={innerRadius}
           outerRadius={radius}
@@ -120,6 +121,7 @@ function SelectionLayer({
           onClick={onClick ? noop : preventDefaultStopPropagation}
           selectionMessage={selectionMessage}
           caretPosition={end + 1}
+          isProtein={isProtein}
           sequenceLength={sequenceLength}
           innerRadius={innerRadius}
           outerRadius={radius}

--- a/packages/ove/src/RowItem/SelectionLayer/index.js
+++ b/packages/ove/src/RowItem/SelectionLayer/index.js
@@ -107,6 +107,7 @@ function SelectionLayer(props) {
                   <Caret
                     key={key + "caret1"}
                     {...{
+                      isProtein,
                       leftMargin,
                       onClick: _onClick || preventDefaultStopPropagation,
                       onRightClick: onSelectionContextMenu,
@@ -129,6 +130,7 @@ function SelectionLayer(props) {
                   <Caret
                     key={key + "caret2"}
                     {...{
+                      isProtein,
                       leftMargin,
                       onClick: _onClick || preventDefaultStopPropagation,
                       onRightClick: onSelectionContextMenu,

--- a/packages/ove/src/RowItem/index.js
+++ b/packages/ove/src/RowItem/index.js
@@ -618,6 +618,7 @@ export default function RowItem(props) {
         {caretPosition > -1 && (
           <Caret
             caretPosition={caretPosition}
+            isProtein={isProtein}
             {...{ ...annotationCommonProps, ...{ getGaps: undefined } }}
             row={
               alignmentData


### PR DESCRIPTION
<!-- please include this @tnrich tag so I get an email :) -->

bug: the caret title will be based on bases instead of amino acid

fix: pass `isProtein` to `Caret` component

@tnrich
