### PR TITLE
Support max insert/paste sequence

### DIFF
--- a/packages/ove/cypress/e2e/copyPaste.js
+++ b/packages/ove/cypress/e2e/copyPaste.js
@@ -42,6 +42,35 @@ describe("copyPaste", function () {
       );
     });
   });
+
+  it('should show warning when pasted sequence is larger than the max insert size', () => {
+    cy.get(`[data-test="moleculeType"]`).select("Protein");
+    cy.tgToggle("addMaxInsertSize");
+    cy.selectRange(10, 12);
+    cy.contains(".veRowViewFeature", "araE")
+      .first()
+      .trigger("contextmenu", { force: true });
+    // cy.contains(".bp3-menu-item", "Copy").trigger("mouseover")
+    cy.contains(".bp3-menu-item", "Copy").click();
+    cy.contains(".openVeCopy2", "Copy").realClick();
+
+    cy.contains("Selection Copied");
+
+    cy.get(`.veVectorInteractionWrapper:focused input`).trigger("paste", {
+        force: true,
+        clipboardData: {
+          // we have to mock the paste event cause cypress doesn't actually trigger a paste event when typing cmd+v
+          getData: type =>
+            type === "application/json"
+              ? JSON.stringify(window.Cypress.seqDataToCopy)
+              : window.Cypress.seqDataToCopy.sequence,
+          types: ["application/json"]
+        }
+      });
+
+      cy.contains("Sorry, the pasted sequence exceeds the maximum allowed length of 100");
+  })
+
   it(`should be able to copy reverse complement`, () => {
     cy.selectRange(10, 12); //select some random range (we were seeing an error where the selection layer wasn't getting updated correctly)
     //right click a feature

--- a/packages/ove/cypress/e2e/proteinEditor.js
+++ b/packages/ove/cypress/e2e/proteinEditor.js
@@ -56,6 +56,23 @@ describe("proteinEditor", function () {
     cy.get(`.tg-test-start input[value="11"]`);
     cy.get(`.tg-test-end [value="31"]`);
   });
+
+  it('should show warning when insert sequence is larger than the max insert size', () => {
+    cy.visit("/#/Editor?moleculeType=Protein&addMaxInsertSize=true");
+    cy.contains("Part - pj5_00001 - Start: 1 End: 1384");
+    cy.contains("Part - pj5_00001 - Start: 1 End: 1384");
+    cy.contains(".veRowViewPrimaryProteinSequenceContainer svg g", "M").click({
+      force: true
+    });
+
+    cy.focused().type("{rightarrow}{rightarrow}");
+
+    cy.get(".veRowViewCaret").trigger("contextmenu", { force: true });
+    cy.contains(".bp3-menu-item", "Insert").click();
+    cy.get(".sequenceInputBubble input").type("aaaaaaaaaaggggggggggaaaaaaaaaaggggggggggaaaaaaaaaaggggggggggaaaaaaaaaaggggggggggaaaaaaaaaaggggggggggc{enter}");
+    cy.contains("Sorry, your insert is greater than 100");
+  })
+
   it(`should be able to insert AAs correctly via typing in the editor`, () => {
     cy.visit("/#/Editor?moleculeType=Protein");
     cy.contains("Part - pj5_00001 - Start: 1 End: 1384");

--- a/packages/ove/demo/src/EditorDemo/index.js
+++ b/packages/ove/demo/src/EditorDemo/index.js
@@ -89,6 +89,7 @@ const defaultState = {
   isFullscreen: false,
   isProtein: false,
   forceHeightMode: false,
+  addMaxInsertSize: false,
   adjustCircularLabelSpacing: false,
   bpLimit: undefined,
   nameFontSizeCircularView: false,
@@ -341,6 +342,7 @@ export default class EditorDemo extends React.Component {
   render() {
     const {
       forceHeightMode,
+      addMaxInsertSize,
       passAutoAnnotateHandlers,
       withAutoAnnotateAddon,
       withGetCustomAutoAnnotateList,
@@ -539,13 +541,13 @@ This feature requires beforeSequenceInsertOrDelete toggle to be true to be enabl
         },
         info: `
         This feature can be used to execute some functionality before closing a panel.  If the function returns true, the panel closes, otherwise it stays open.
-        
+
 \`\`\`
 onPanelTabClose: (panelId) => {
     window.toastr.success('onPanelClose callback triggered.');
     return confirm("Close panel?")
   }
-    
+
 `
       })
     ].filter(i => i);
@@ -1199,6 +1201,12 @@ rightClickOverrides: {
                 type: "forceHeightMode",
                 label: "Force Height 500px",
                 info: "You can force a height for the editor by passing `height:500` (same for width) "
+              })}
+              {renderToggle({
+                that: this,
+                type: "addMaxInsertSize",
+                label: "Add Max Insert Size 100",
+                info: "You can change the max size for insert/copy for the editor by passing `maxInsertSize:100`"
               })}
               {renderToggle({
                 that: this,
@@ -2714,6 +2722,7 @@ doubleClickOverrides: {
             })}
             generatePng={generatePng}
             {...(forceHeightMode && { height: 500 })}
+            {...(addMaxInsertSize && { maxInsertSize: 100 })}
             {...(adjustCircularLabelSpacing && { fontHeightMultiplier: 2 })}
             {...(bpLimit && { bpLimit: 8000 })}
             {...(withVersionHistory && {

--- a/packages/ove/demo/src/EditorDemo/index.js
+++ b/packages/ove/demo/src/EditorDemo/index.js
@@ -1206,7 +1206,7 @@ rightClickOverrides: {
                 that: this,
                 type: "addMaxInsertSize",
                 label: "Add Max Insert Size 100",
-                info: "You can change the max size for insert/copy for the editor by passing `maxInsertSize:100`"
+                info: "You can change the max size for insert/paste for the editor by passing `maxInsertSize:100`"
               })}
               {renderToggle({
                 that: this,

--- a/packages/ove/src/Editor/index.js
+++ b/packages/ove/src/Editor/index.js
@@ -360,6 +360,7 @@ export class Editor extends React.Component {
       hideStatusBar,
       hoveredId,
       isFullscreen,
+      maxInsertSize,
       maxAnnotationsToDisplay,
       minHeight = 400,
       onlyShowLabelsThatDoNotFit = true,
@@ -592,6 +593,7 @@ export class Editor extends React.Component {
           doubleClickOverrides={this.props.doubleClickOverrides}
           {...panelPropsToSpread}
           editorName={editorName}
+          maxInsertSize={maxInsertSize}
           isProtein={sequenceData.isProtein}
           onlyShowLabelsThatDoNotFit={onlyShowLabelsThatDoNotFit}
           tabHeight={tabHeight}

--- a/packages/ove/src/withEditorInteractions/createSequenceInputPopup.js
+++ b/packages/ove/src/withEditorInteractions/createSequenceInputPopup.js
@@ -154,10 +154,9 @@ class SequenceInputNoHotkeys extends React.Component {
                 });
               }, 200);
             }
-            if (maxInsertSize && sanitizedVal.lenth > maxInsertSize) {
+            if (maxInsertSize && sanitizedVal.length > maxInsertSize) {
               return window.toastr.error(
-                "Sorry, your insert is greater than ",
-                maxInsertSize
+                `Sorry, your insert is greater than ${maxInsertSize}`,
               );
             }
             e.target.value = sanitizedVal;

--- a/packages/ove/src/withEditorInteractions/index.js
+++ b/packages/ove/src/withEditorInteractions/index.js
@@ -211,7 +211,8 @@ function VectorInteractionHOC(Component /* options */) {
         readOnly,
         onPaste,
         disableBpEditing,
-        sequenceData
+        sequenceData,
+        maxInsertSize
       } = this.props;
 
       if (disableBpEditing) {
@@ -239,6 +240,12 @@ function VectorInteractionHOC(Component /* options */) {
       }
       if (sequenceData.isProtein && !seqDataToInsert.proteinSequence) {
         seqDataToInsert.proteinSequence = seqDataToInsert.sequence;
+      }
+
+      if (maxInsertSize && (seqDataToInsert.proteinSequence || seqDataToInsert.sequence).length > maxInsertSize) {
+        return window.toastr.error(
+          `Sorry, the pasted sequence exceeds the maximum allowed length of ${maxInsertSize}`
+        );
       }
 
       seqDataToInsert = tidyUpSequenceData(seqDataToInsert, {
@@ -387,7 +394,8 @@ function VectorInteractionHOC(Component /* options */) {
         selectionLayer = { start: -1, end: -1 },
         sequenceData = { sequence: "" },
         readOnly,
-        disableBpEditing
+        disableBpEditing,
+        maxInsertSize,
         // updateSequenceData,
         // wrappedInsertSequenceDataAtPositionOrRange
         // handleInsert
@@ -408,6 +416,7 @@ function VectorInteractionHOC(Component /* options */) {
           selectionLayer,
           sequenceLength,
           caretPosition,
+          maxInsertSize,
           handleInsert: async seqDataToInsert => {
             await insertAndSelectHelper({
               props: this.props,


### PR DESCRIPTION
<!-- please include this @tnrich tag so I get an email :) -->
to avoid insert/paste too many sequence at a time and lead to some potential performance issue, we may need to support limiting the max insert/paste size at a time by passing a parameter `maxInsertSize`, this property is used by existing code, but not working, so I did some changes to make this property work
@tnrich
