### PR TITLE
fix protein selection issue after replace action & fix two window issue

### DIFF
--- a/packages/ove/src/withEditorInteractions/createSequenceInputPopup.js
+++ b/packages/ove/src/withEditorInteractions/createSequenceInputPopup.js
@@ -221,6 +221,10 @@ export default function createSequenceInputPopup(props) {
   // function closeInput() {
   //   sequenceInputBubble.remove();
   // }
+  if (document.getElementById("sequenceInputBubble")) {
+    // remove the old one if it exists
+    document.getElementById("sequenceInputBubble").outerHTML = "";
+  }
   div = document.createElement("div");
   div.style.zIndex = "400000";
   div.id = "sequenceInputBubble";

--- a/packages/ove/src/withEditorInteractions/index.js
+++ b/packages/ove/src/withEditorInteractions/index.js
@@ -238,8 +238,12 @@ function VectorInteractionHOC(Component /* options */) {
           sequence: clipboardData.getData("text/plain") || e.target.value
         };
       }
-      if (sequenceData.isProtein && !seqDataToInsert.proteinSequence) {
-        seqDataToInsert.proteinSequence = seqDataToInsert.sequence;
+      if (sequenceData.isProtein) {
+        seqDataToInsert.isProtein = true;
+
+        if (!seqDataToInsert.proteinSequence) {
+          seqDataToInsert.proteinSequence = seqDataToInsert.sequence;
+        }
       }
 
       if (

--- a/packages/sequence-utils/src/filterSequenceString.js
+++ b/packages/sequence-utils/src/filterSequenceString.js
@@ -112,7 +112,6 @@ export function getAcceptedChars({
           ? ambiguous_rna_letters.toLowerCase() +
             ambiguous_dna_letters.toLowerCase()
           : //just plain old dna
-            ambiguous_rna_letters.toLowerCase() +
             ambiguous_dna_letters.toLowerCase();
 }
 export function getReplaceChars({


### PR DESCRIPTION
<!-- please include this @tnrich tag so I get an email :) -->
issue 1: we can see two input window at the same time
issue 2: select one protein amino acid and replace with 8 amino acids, then the selected amino acids is not 8 but 1.
![two_window](https://github.com/user-attachments/assets/1e0557d1-49e6-4b9a-970c-0753a3aeffaa)

@tnrich
