### PR TITLE
bump seq utils

### DIFF
--- a/packages/sequence-utils/package.json
+++ b/packages/sequence-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teselagen/sequence-utils",
-  "version": "0.3.32",
+  "version": "0.3.33",
   "type": "module",
   "dependencies": {
     "escape-string-regexp": "5.0.0",


### PR DESCRIPTION
<!-- please include this @tnrich tag so I get an email :) -->

@tnrich I noticed there have been updates to packages/sequence-utils/src/threeLetterSequenceStringToAminoAcidMap.js. As a result, the function getAminoAcidDataForEachBaseOfDna is now returning different results. So the package needs update.
