### PR TITLE
feat(ove): add PropertiesProps support for custom annotation columns

### DIFF
--- a/packages/ove/src/Editor/index.js
+++ b/packages/ove/src/Editor/index.js
@@ -77,7 +77,7 @@ const _panelMap = {
   pcrTool: PCRTool,
   properties: {
     comp: Properties,
-    panelSpecificPropsToSpread: ["PropertiesProps"]
+    panelSpecificProps: ["PropertiesProps"]
   },
   mismatches: Mismatches
 };

--- a/packages/ove/src/helperComponents/PropertiesDialog/GenericAnnotationProperties.js
+++ b/packages/ove/src/helperComponents/PropertiesDialog/GenericAnnotationProperties.js
@@ -68,7 +68,8 @@ const genericAnnotationProperties = ({
         allPartTags,
         annotationPropertiesSelectedEntities:
           _annotationPropertiesSelectedEntities,
-        selectedAnnotationId
+        selectedAnnotationId,
+        PropertiesProps
       } = this.props;
       const annotationPropertiesSelectedEntities =
         _annotationPropertiesSelectedEntities.filter(a => annotations[a.id]);
@@ -86,6 +87,9 @@ const genericAnnotationProperties = ({
       });
 
       const keyedPartTags = getKeyedTagsAndTagOptions(allPartTags) ?? {};
+
+      const additionalColumns =
+        PropertiesProps?.[annotationType]?.additionalColumns || [];
 
       this.schema = {
         fields: [
@@ -194,7 +198,8 @@ const genericAnnotationProperties = ({
                 }
               ]
             : []),
-          { path: "strand", type: "number" }
+          { path: "strand", type: "number" },
+          ...additionalColumns
         ]
       };
 
@@ -351,15 +356,19 @@ const genericAnnotationProperties = ({
 
   return compose(
     connectToEditor(
-      ({
-        readOnly,
-        annotationVisibility = {},
-        sequenceData,
-        selectionLayer,
-        featureLengthsToHide,
-        primerLengthsToHide,
-        partLengthsToHide
-      }) => {
+      (
+        {
+          readOnly,
+          annotationVisibility = {},
+          sequenceData,
+          selectionLayer,
+          featureLengthsToHide,
+          primerLengthsToHide,
+          partLengthsToHide,
+          PropertiesProps
+        },
+        ownProps
+      ) => {
         return {
           annotationVisibility,
           selectionLayer,
@@ -371,7 +380,8 @@ const genericAnnotationProperties = ({
           sequence: sequenceData.sequence,
           annotations: sequenceData[annotationType + "s"],
           [annotationType + "s"]: sequenceData[annotationType + "s"],
-          sequenceLength: sequenceData.sequence.length
+          sequenceLength: sequenceData.sequence.length,
+          PropertiesProps: ownProps.PropertiesProps || PropertiesProps
         };
       }
     ),

--- a/packages/ove/src/helperComponents/PropertiesDialog/index.js
+++ b/packages/ove/src/helperComponents/PropertiesDialog/index.js
@@ -114,6 +114,7 @@ export const PropertiesDialog = props => {
               showAvailability,
               disableSetReadOnly,
               selectedAnnotationId,
+              PropertiesProps: props.PropertiesProps,
               ...(nameOrOverride.name && nameOrOverride)
             }}
           />

--- a/packages/ove/src/utils/getAnnotationNameAndStartStopString.js
+++ b/packages/ove/src/utils/getAnnotationNameAndStartStopString.js
@@ -40,22 +40,16 @@ export default function getAnnotationNameAndStartStopString(
     end = start - 1;
     start = oldEnd + 1;
   }
+
+  const interactionInstructions = readOnly
+    ? ""
+    : annotationTypePlural === "cutsites"
+      ? `\n\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n  INTERACTIONS:\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n   click → top cut position\n   alt/option+click → bottom cut position\n   cmd/ctrl+click → recognition range`
+      : `\n\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n  INTERACTIONS:\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n   alt/option+click → jump row view to start/end\n   double click → edit`;
+
   return `${startText ? startText : ""} ${typeToUse ? typeToUse + " -" : ""} ${
     name ? name : ""
   } - Start: ${isProtein ? (start + 3) / 3 : start + 1} End: ${
     isProtein ? (end + 1) / 3 : end + 1
-  } ${overlapsSelf ? "(Overlaps Self) " : ""}${message ? "\n" + message : ""} ${
-    readOnly
-      ? ""
-      : annotationTypePlural === "cutsites"
-        ? `
-
- click --> top cut position
- alt/option+click --> bottom cut position
- cmd/ctrl+click --> recognition range`
-        : `
-
-alt/option+click --> jump row view to start/end
-double click --> edit`
-  }`;
+  } ${overlapsSelf ? "(Overlaps Self) " : ""}${message ? "\n" + message : ""}${interactionInstructions}`;
 }


### PR DESCRIPTION
- Add additionalColumns support to GenericAnnotationProperties via PropertiesProps
- Update PropertiesDialog to pass PropertiesProps to child components
- Modify Editor to use panelSpecificProps instead of panelSpecificPropsToSpread
- Enable LIMS to inject custom columns without modifying tg-oss code
- Support message prop in getAnnotationNameAndStartStopString for custom tooltips

@tnrich
