### PR TITLE
Fix the bug in the linear sequence recognition.

### DIFF
--- a/packages/bio-parsers/src/genbankToJson.js
+++ b/packages/bio-parsers/src/genbankToJson.js
@@ -739,6 +739,16 @@ function genbankToJson(string, options = {}) {
             : undefined;
       delete feat.notes.direction;
     }
+    if (
+      feat.locations &&
+      feat.locations.length > 1 &&
+      feat.locations[0].start > feat.locations[feat.locations.length - 1].end
+    ) {
+      if (parsedSequence.circular === undefined) {
+        //if the circularity hasn't been explicitly defined, and we have a feature that wraps the origin, we can assume the sequence is circular
+        parsedSequence.circular = true;
+      }
+    }
     if (parsedSequence.circular) {
       const { inclusive1BasedStart, inclusive1BasedEnd } = options;
       feat.locations = wrapOriginSpanningFeatures(
@@ -747,6 +757,9 @@ function genbankToJson(string, options = {}) {
         inclusive1BasedStart,
         inclusive1BasedEnd
       );
+    } else if (feat.locations && feat.locations.length > 1) {
+      // Sort locations for linear sequences
+      feat.locations.sort((a, b) => a.start - b.start);
     }
 
     return feat;


### PR DESCRIPTION
If the locations array of a feature in the linear sequence is not arranged in ascending order—for example, as shown in the image below recognition will encounter problems.
<img width="833" height="85" alt="Screenshot 2025-11-03 093441" src="https://github.com/user-attachments/assets/aca4b858-56fe-4fd5-9957-c1e1039a62f3" />

before fix:
<img width="1872" height="833" alt="image" src="https://github.com/user-attachments/assets/46f0149f-b12f-445f-93e1-6e29f3d8b57b" />

after fix:
<img width="1614" height="864" alt="image" src="https://github.com/user-attachments/assets/8e69e9c6-e646-4d60-a79e-6fffd46dbc6f" />



@tnrich
