### PR TITLE
fix: update frequency table header to reflect sequence type

### DIFF
--- a/packages/ove/src/PropertySidePanel/index.js
+++ b/packages/ove/src/PropertySidePanel/index.js
@@ -149,7 +149,9 @@ export default ({ properties, setProperties, style }) => {
         <h5>{isProtein ? "Amino Acid" : "Base Pair"} Frequencies</h5>
         <div className="sidebar-table">
           <div className="sidebar-row">
-            <div className="sidebar-cell">Amino Acid</div>
+            <div className="sidebar-cell">
+              {isProtein ? "Amino Acid" : "Base"}
+            </div>
             <div className="sidebar-cell">Count</div>
             <div className="sidebar-cell">Percentage</div>
           </div>


### PR DESCRIPTION
This pull request makes a minor improvement to the `PropertySidePanel` component by updating the label in the frequencies table to more accurately reflect whether the sequence is a protein or a nucleotide sequence.

* The "Amino Acid" column label in the sidebar table now dynamically displays "Amino Acid" for proteins and "Base" for nucleotide sequences, improving clarity for users.

connects [#14207](https://github.com/TeselaGen/lims/issues/14207)

@tnrich
