### PR TITLE
add primers to LinearView annotation paring logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ node_modules
 *.launch
 .settings/
 *.sublime-workspace
+/.zed
 
 # IDE - VSCode
 .vscode/*

--- a/packages/ove/src/LinearView/index.js
+++ b/packages/ove/src/LinearView/index.js
@@ -104,32 +104,34 @@ class _LinearView extends React.Component {
     } = this.props;
     // if (!isEqual(sequenceData, this.oldSeqData)) {
     this.paredDownMessages = [];
-    const paredDownSeqData = ["parts", "features", "cutsites"].reduce(
-      (acc, type) => {
-        const nameUpper = startCase(type);
-        const maxToShow =
-          (maxAnnotationsToDisplay
-            ? maxAnnotationsToDisplay[type]
-            : limits[type]) || 50;
-        const [annotations, paredDown] = pareDownAnnotations(
-          sequenceData["filtered" + nameUpper] || sequenceData[type] || {},
-          maxToShow
-        );
+    const paredDownSeqData = [
+      "parts",
+      "features",
+      "cutsites",
+      "primers"
+    ].reduce((acc, type) => {
+      const nameUpper = startCase(type);
+      const maxToShow =
+        (maxAnnotationsToDisplay
+          ? maxAnnotationsToDisplay[type]
+          : limits[type]) || 50;
+      const [annotations, paredDown] = pareDownAnnotations(
+        sequenceData["filtered" + nameUpper] || sequenceData[type] || {},
+        maxToShow
+      );
 
-        if (paredDown) {
-          this.paredDownMessages.push(
-            getParedDownWarning({
-              nameUpper,
-              isAdjustable: !maxAnnotationsToDisplay,
-              maxToShow
-            })
-          );
-        }
-        acc[type] = annotations;
-        return acc;
-      },
-      {}
-    );
+      if (paredDown) {
+        this.paredDownMessages.push(
+          getParedDownWarning({
+            nameUpper,
+            isAdjustable: !maxAnnotationsToDisplay,
+            maxToShow
+          })
+        );
+      }
+      acc[type] = annotations;
+      return acc;
+    }, {});
     this.rowData = prepareRowData(
       {
         ...sequenceData,


### PR DESCRIPTION
Added `"primers"` to the list of annotation types processed in the `paredDownSeqData` reduction, so primers are now included in the pared-down annotations shown in the linear view.

@tnrich
