### PR TITLE
fix locations issue of feature

### DIFF
--- a/packages/sequence-utils/src/getSequenceDataBetweenRange.js
+++ b/packages/sequence-utils/src/getSequenceDataBetweenRange.js
@@ -1,5 +1,5 @@
 import { flatMap, extend, forEach, startCase } from "lodash-es";
-import { getRangeLength } from "@teselagen/range-utils";
+import { getRangeLength, isRangeWithinRange } from "@teselagen/range-utils";
 import convertDnaCaretPositionOrRangeToAa from "./convertDnaCaretPositionOrRangeToAA";
 import insertSequenceDataAtPosition from "./insertSequenceDataAtPosition";
 import {
@@ -112,7 +112,16 @@ function getAnnotationsBetweenRange(
     const overlaps = getZeroedRangeOverlaps(annotation, range, maxLength).map(
       overlap => {
         //we get back 1 or more overlaps here
-
+        const allLocations = annotation.locations;
+        if (allLocations && allLocations.length) {
+          // Filter the 'allLocations' that in this overlap
+          const newLocations = allLocations.filter(loc => {
+            return isRangeWithinRange(loc, overlap, maxLength);
+          })
+          return extend({}, annotation, overlap, {
+            locations: newLocations
+          });
+        }
         return extend({}, annotation, overlap);
       }
     );

--- a/packages/sequence-utils/src/getSequenceDataBetweenRange.test.js
+++ b/packages/sequence-utils/src/getSequenceDataBetweenRange.test.js
@@ -462,4 +462,46 @@ describe("getSequenceDataBetweenRange", () => {
       ]
     });
   });
+  it("feature with locations, circular sequence, non-fully enclosing range range that cross the origin", () =>{
+    const res = getSequenceDataBetweenRange(
+      {
+        circular: true,
+        sequence: "gggatgcatgca",
+        features: [
+          {
+            start: 5,
+            end: 3,
+            locations: [
+              { start: 5, end: 6 },
+              { start: 7, end: 8 },
+              { start: 9, end: 1 },
+              { start: 2, end: 3 }
+            ],
+            name: "testing"
+          }
+        ]
+      },
+      {
+        start: 2,
+        end: 7
+      }
+    );
+    res.should.containSubset({
+      sequence: "gatgca",
+      features: [
+        {
+          start: 0,
+          end: 1,
+          name: "testing",
+          locations: undefined
+        },
+        {
+          start: 3,
+          end: 5,
+          name: "testing",
+          locations: [{start:3, end:4}, {start:5, end:5}]
+        }
+      ]
+    });
+  })
 });


### PR DESCRIPTION
<!-- please include this @tnrich tag so I get an email :) -->

some issue caused by the function `getSequenceDataBetweenRange`
duplicated features are in the copied genbank content
![copy_genbak_bug](https://github.com/user-attachments/assets/12f5db20-a021-4971-8328-09980f7c8570)

root cause:
we use `extend({}, annotation, overlap)` to create two partial features from one feature, but the created two partial features are with same `locations` and then use the `locations` to reset the `annotation.start` and `annotation.end`, so the `start` and the `end` of the two partial feature will also be same.


@tnrich
