### PR TITLE
feat(DataTable): copy as text/html so paste into rich-text editors keeps the table

### DIFF
--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.10.24 (2026-05-22)
+
+- feat: DataTable copy now also writes `text/html` to the clipboard, so pasting into rich-text editors (ELN, Google Docs, Notion) keeps the table structure
+
 ## 0.10.23 (2026-05-05)
 
 - fix: add data-test-value to select to help w testing

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teselagen/ui",
-  "version": "0.10.23",
+  "version": "0.10.24",
   "main": "./src/index.js",
   "type": "module",
   "repository": "https://github.com/TeselaGen/tg-oss",

--- a/packages/ui/src/DataTable/utils/handleCopyHelper.js
+++ b/packages/ui/src/DataTable/utils/handleCopyHelper.js
@@ -1,10 +1,12 @@
 import copy from "copy-to-clipboard";
+import { tsvToHtmlTable } from "./tsvToHtmlTable";
 
 export const handleCopyHelper = (stringToCopy, jsonToCopy, message) => {
   !window.Cypress &&
     copy(stringToCopy, {
       onCopy: clipboardData => {
         clipboardData.setData("application/json", JSON.stringify(jsonToCopy));
+        clipboardData.setData("text/html", tsvToHtmlTable(stringToCopy));
       },
       // keep this so that pasting into spreadsheets works.
       format: "text/plain"

--- a/packages/ui/src/DataTable/utils/tsvToHtmlTable.js
+++ b/packages/ui/src/DataTable/utils/tsvToHtmlTable.js
@@ -1,0 +1,23 @@
+const HTML_ESCAPES = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;"
+};
+
+const escapeHtml = value =>
+  String(value ?? "").replace(/[&<>"]/g, c => HTML_ESCAPES[c]);
+
+export const tsvToHtmlTable = tsv => {
+  const rows = String(tsv ?? "")
+    .split("\n")
+    .map(line => {
+      const cells = line
+        .split("\t")
+        .map(v => `<td>${escapeHtml(v)}</td>`)
+        .join("");
+      return `<tr>${cells}</tr>`;
+    })
+    .join("");
+  return `<table>${rows}</table>`;
+};

--- a/packages/ui/src/DataTable/utils/tsvToHtmlTable.test.js
+++ b/packages/ui/src/DataTable/utils/tsvToHtmlTable.test.js
@@ -1,0 +1,41 @@
+import { tsvToHtmlTable } from "./tsvToHtmlTable";
+
+describe("tsvToHtmlTable", () => {
+  it("wraps a single row in a <table>", () => {
+    expect(tsvToHtmlTable("a\tb\tc")).toBe(
+      "<table><tr><td>a</td><td>b</td><td>c</td></tr></table>"
+    );
+  });
+
+  it("splits rows on newline and cells on tab", () => {
+    expect(tsvToHtmlTable("h1\th2\n1\t2\nA\tB")).toBe(
+      "<table>" +
+        "<tr><td>h1</td><td>h2</td></tr>" +
+        "<tr><td>1</td><td>2</td></tr>" +
+        "<tr><td>A</td><td>B</td></tr>" +
+        "</table>"
+    );
+  });
+
+  it("escapes HTML-significant characters in cell content", () => {
+    expect(tsvToHtmlTable('<b>&"x"</b>\tnormal')).toBe(
+      "<table><tr><td>&lt;b&gt;&amp;&quot;x&quot;&lt;/b&gt;</td><td>normal</td></tr></table>"
+    );
+  });
+
+  it("preserves empty cells and empty rows", () => {
+    expect(tsvToHtmlTable("a\t\tb\n\nc")).toBe(
+      "<table>" +
+        "<tr><td>a</td><td></td><td>b</td></tr>" +
+        "<tr><td></td></tr>" +
+        "<tr><td>c</td></tr>" +
+        "</table>"
+    );
+  });
+
+  it("handles empty/null input", () => {
+    expect(tsvToHtmlTable("")).toBe("<table><tr><td></td></tr></table>");
+    expect(tsvToHtmlTable(null)).toBe("<table><tr><td></td></tr></table>");
+    expect(tsvToHtmlTable(undefined)).toBe("<table><tr><td></td></tr></table>");
+  });
+});


### PR DESCRIPTION
## Summary

- `DataTable` copy currently writes only `text/plain` (TSV) and `application/json` to the clipboard. Pasting into rich-text editors (LIMS ELN, Google Docs, Notion, Word) flattens the data into raw lines instead of a table.
- This change adds a `text/html` payload to the clipboard inside the existing `onCopy` callback in `handleCopyHelper`, built from the same TSV string the caller already produces.
- All copy paths benefit transparently: `handleCopyRows`, `handleCopyColumn`, `handleCopyTable`, and the in-component `handleCopySelectedCells`.

## Motivation

Tracked by TeselaGen/lims#13380 (board: USP). Repro: copy a few rows from a DataTable record view → paste into an ELN entry → only raw lines, no table.

## Changes

- `packages/ui/src/DataTable/utils/handleCopyHelper.js` — also call `clipboardData.setData("text/html", tsvToHtmlTable(stringToCopy))`. `text/plain` and `application/json` are unchanged.
- `packages/ui/src/DataTable/utils/tsvToHtmlTable.js` — new helper that splits the TSV string by `\n` / `\t`, HTML-escapes `& < > "`, and wraps the cells in `<table><tr><td>…</td></tr></table>`.
- `packages/ui/src/DataTable/utils/tsvToHtmlTable.test.js` — unit tests for single/multi row, HTML escaping, empty cells/rows, and null/undefined input.

## Behavior matrix

| Paste target | Before | After |
|---|---|---|
| Google Sheets / Excel | columns split by `\t` (works) | unchanged — `text/plain` TSV still wins |
| ELN / Google Docs / Notion | raw lines | real `<table>` |
| In-app DataTable (uses `application/json`) | unchanged | unchanged |

## Test plan

- [x] Bun unit tests: `bun test packages/ui/src/DataTable/utils/` → 78 pass.
- [x] Full ui test suite: `bun test packages/ui` → 96 pass.
- [x] Lint: `npx eslint` on the three changed files → clean.
- [ ] Manual: in the consumer apps (LIMS), copy from a DataTable and paste into rich-text editors / spreadsheets to confirm both formats behave as expected.

## Notes

- HTML structure intentionally minimal (`<table><tr><td>`) — no `<thead>`/`<tbody>`/`<th>` — to keep the helper format-agnostic. The TSV doesn't carry header semantics today; if needed, headers can be wired in later.
- Cypress path is preserved: the `!window.Cypress` guard still short-circuits copy in test runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)