### PR TITLE
Make findApproxMatches case-insensitive

### DIFF
--- a/packages/ove/CHANGELOG.md
+++ b/packages/ove/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.43 (2026-06-04)
+
+- fix: case-insensitive approximate match search in alignment view
+
 ## 0.8.42 (2026-04-16)
 
 - fix: better color parsing for snapgene files

--- a/packages/ove/demo/src/exampleData/exampleSequenceData.js
+++ b/packages/ove/demo/src/exampleData/exampleSequenceData.js
@@ -38,7 +38,9 @@ export default {
   ],
   features: [
     {
-      notes: {},
+      notes: {
+        codon_start: [3]
+      },
       type: "CDS",
       strand: -1,
       name: "araC",

--- a/packages/ove/package.json
+++ b/packages/ove/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teselagen/ove",
-  "version": "0.8.42",
+  "version": "0.8.43",
   "main": "./src/index.js",
   "type": "module",
   "repository": "https://github.com/TeselaGen/tg-oss",

--- a/packages/ove/src/AlignmentView/AlignmentSearchBar.js
+++ b/packages/ove/src/AlignmentView/AlignmentSearchBar.js
@@ -214,8 +214,8 @@ export function AlignmentSearchBar(props) {
           mismatchesAllowed > 0
         ) {
           const approxMatches = findApproxMatches(
-            query.toLowerCase(),
-            rawSeq.toLowerCase(),
+            query,
+            rawSeq,
             mismatchesAllowed,
             false
           );

--- a/packages/sequence-utils/CHANGELOG.md
+++ b/packages/sequence-utils/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.43 (2026-06-04)
+
+- fix: make findApproxMatches case-insensitive
+
 ## 0.3.41 (2025-01-05)
 
 - Initialize changelog

--- a/packages/sequence-utils/package.json
+++ b/packages/sequence-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teselagen/sequence-utils",
-  "version": "0.3.42",
+  "version": "0.3.43",
   "repository": "https://github.com/TeselaGen/tg-oss",
   "type": "module",
   "dependencies": {

--- a/packages/sequence-utils/src/findApproxMatches.js
+++ b/packages/sequence-utils/src/findApproxMatches.js
@@ -14,6 +14,7 @@ export default function findApproxMatches(
   circular = false
 ) {
   const matches = [];
+  const searchLower = searchSeq.toLowerCase();
   const lenA = searchSeq.length;
   const lenB = targetSeq.length;
 
@@ -25,11 +26,12 @@ export default function findApproxMatches(
 
   for (let i = 0; i < limit; i++) {
     const window = targetSeqExtended.slice(i, i + lenA);
+    const windowLower = window.toLowerCase();
     let mismatchCount = 0;
     const mismatchPositions = [];
 
     for (let j = 0; j < lenA; j++) {
-      if (searchSeq[j] !== window[j]) {
+      if (searchLower[j] !== windowLower[j]) {
         mismatchPositions.push(j);
         mismatchCount++;
         if (mismatchCount > maxMismatches) break;

--- a/packages/sequence-utils/src/findApproxMatches.test.js
+++ b/packages/sequence-utils/src/findApproxMatches.test.js
@@ -110,6 +110,16 @@ describe("findApproxMatches", () => {
     expect(actual).toEqual(expected);
   });
 
+  it("is case insensitive", () => {
+    expect(findApproxMatches("atg", "GATGC", 0)).toEqual([
+      { index: 1, match: "ATG", mismatchPositions: [], numMismatches: 0 }
+    ]);
+
+    expect(findApproxMatches("ATG", "actg", 1)).toEqual([
+      { index: 1, match: "ctg", mismatchPositions: [0], numMismatches: 1 }
+    ]);
+  });
+
   it("tracks exact positions of mismatches", () => {
     // Test specific positions of mismatches
     const result = findApproxMatches("ATGCTA", "ATCCAA", 2);


### PR DESCRIPTION
Hi @tnrich,

Just came across the approx matching functionality. Super nice feature, I am already using it. I noticed that it was not case-insensitive when typing on the search box, to reproduce in the demo:

<img width="667" height="287" alt="Screenshot 2026-05-27 at 10 21 15" src="https://github.com/user-attachments/assets/ff4dd775-2c72-4f9d-8a7e-bc117a88b3c6" />

I fixed it by making the function case-insensitive. Alternatively, I could have passed .toLowerCase() to both query and target, like in `AlignmentSearchBar` (now removed), but I felt like this was less error-prone for future uses.

Thanks again for the great library!